### PR TITLE
feat: 현재 듣는 음악의 Artwork에 따른 배경색 지정 

### DIFF
--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		2003BA142CDB8300002CAB3E /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 2003BA0B2CDB8300002CAB3E /* Pretendard-Bold.otf */; };
 		2003BA162CDB8D69002CAB3E /* Font+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2003BA152CDB8D69002CAB3E /* Font+Extension.swift */; };
 		2003BA1C2CDB8EE5002CAB3E /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2003BA1B2CDB8EE5002CAB3E /* UILabel+Extension.swift */; };
+		2003BA222CDCB31B002CAB3E /* SwipeMusicViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2003BA212CDCB31B002CAB3E /* SwipeMusicViewModel.swift */; };
 		B80970802CDB4455007BC3C4 /* Base.swift in Sources */ = {isa = PBXBuildFile; fileRef = B809707F2CDB4455007BC3C4 /* Base.swift */; };
 		B80970852CDB44E3007BC3C4 /* Entity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80970842CDB44E3007BC3C4 /* Entity.swift */; };
 		B80970872CDB44F7007BC3C4 /* RepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80970862CDB44F7007BC3C4 /* RepositoryInterface.swift */; };
@@ -54,6 +55,7 @@
 		2003BA152CDB8D69002CAB3E /* Font+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Extension.swift"; sourceTree = "<group>"; };
 		2003BA172CDB8DE0002CAB3E /* Text+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+Extension.swift"; sourceTree = "<group>"; };
 		2003BA1B2CDB8EE5002CAB3E /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
+		2003BA212CDCB31B002CAB3E /* SwipeMusicViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeMusicViewModel.swift; sourceTree = "<group>"; };
 		B809707F2CDB4455007BC3C4 /* Base.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base.swift; sourceTree = "<group>"; };
 		B80970842CDB44E3007BC3C4 /* Entity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entity.swift; sourceTree = "<group>"; };
 		B80970862CDB44F7007BC3C4 /* RepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryInterface.swift; sourceTree = "<group>"; };
@@ -331,6 +333,7 @@
 		F173691C2CDB991D00F6242C /* SwipeMusic */ = {
 			isa = PBXGroup;
 			children = (
+				2003BA212CDCB31B002CAB3E /* SwipeMusicViewModel.swift */,
 				F173691D2CDB992700F6242C /* View */,
 			);
 			path = SwipeMusic;
@@ -443,6 +446,7 @@
 				2003BA162CDB8D69002CAB3E /* Font+Extension.swift in Sources */,
 				F17368FD2CD86B1100F6242C /* ViewController.swift in Sources */,
 				B80970962CDB45EE007BC3C4 /* DTO.swift in Sources */,
+				2003BA222CDCB31B002CAB3E /* SwipeMusicViewModel.swift in Sources */,
 				B80970892CDB451D007BC3C4 /* UseCase.swift in Sources */,
 				F173691F2CDB995100F6242C /* SwipeMusicViewController.swift in Sources */,
 				B80970872CDB44F7007BC3C4 /* RepositoryInterface.swift in Sources */,

--- a/Molio/Source/Presentation/SwipeMusic/SwipeMusicViewModel.swift
+++ b/Molio/Source/Presentation/SwipeMusic/SwipeMusicViewModel.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Combine
+import MusicKit
+
+class SwipeMusicViewModel: ObservableObject {
+    @Published var music: Song?
+    let musicService = MusicKitService()
+    
+    func fetchMusic() {
+        if musicService.checkAuthorizationStatus() {
+            Task {
+                let music = await musicService.getMusic(with: "USAT22409172")
+                self.music = music
+            }
+        } else {
+            music = nil
+        }
+    }
+}

--- a/Molio/Source/Presentation/SwipeMusic/SwipeMusicViewModel.swift
+++ b/Molio/Source/Presentation/SwipeMusic/SwipeMusicViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import Combine
 import MusicKit
 
-class SwipeMusicViewModel: ObservableObject {
+final class SwipeMusicViewModel: ObservableObject {
     @Published var music: Song?
     let musicService = MusicKitService()
     

--- a/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
+++ b/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
@@ -79,7 +79,6 @@ final class SwipeMusicViewController: UIViewController {
         
         setupBindings()
         viewModel.fetchMusic()
-        
     }
     
     private func setupBindings() {

--- a/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
+++ b/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
@@ -1,6 +1,11 @@
 import UIKit
+import Combine
 
 final class SwipeMusicViewController: UIViewController {
+    private var viewModel = SwipeMusicViewModel()
+    private var cancellables = Set<AnyCancellable>()
+
+    let basicBackgroundColor = UIColor(named: "background")
     
     private let playlistSelectButton: UIButton = {
         let button = UIButton()
@@ -67,10 +72,27 @@ final class SwipeMusicViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.navigationBar.isHidden = true
-        view.backgroundColor = .white // TODO: 앨범의 배경색으로 지정된 이후 삭제
+        view.backgroundColor = basicBackgroundColor // TODO: 앨범의 배경색으로 지정된 이후 삭제
         setupSelectPlaylistView()
         setupMusicTrackView()
         setupMenuButtonView()
+        
+        setupBindings()
+        viewModel.fetchMusic()
+        
+    }
+    
+    private func setupBindings() {
+        viewModel.$music
+            .receive(on: RunLoop.main) // 메인 스레드에서 UI 업데이트
+            .sink { [weak self] music in
+                self?.setupBackgroundColor(by: music?.artwork?.backgroundColor)
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func setupBackgroundColor(by cgColor: CGColor?){
+        view.backgroundColor = cgColor.map(UIColor.init(cgColor:)) ?? basicBackgroundColor
     }
     
     private func setupSelectPlaylistView() {
@@ -125,5 +147,24 @@ final class SwipeMusicViewController: UIViewController {
             menuStackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             menuStackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -22)
         ])
+    }
+}
+
+// SwiftUI에서 SwipeViewController 미리보기
+import SwiftUI
+struct SwipeViewControllerPreview: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> SwipeMusicViewController {
+        return SwipeMusicViewController()
+    }
+    
+    func updateUIViewController(_ uiViewController: SwipeMusicViewController, context: Context) {
+        
+    }
+}
+
+struct SwipeViewController_Previews: PreviewProvider {
+    static var previews: some View {
+        SwipeViewControllerPreview()
+            .edgesIgnoringSafeArea(.all)
     }
 }

--- a/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
+++ b/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 import Combine
 
 final class SwipeMusicViewController: UIViewController {
-    private var viewModel = SwipeMusicViewModel()
+    private let viewModel = SwipeMusicViewModel()
     private var cancellables = Set<AnyCancellable>()
 
     let basicBackgroundColor = UIColor(named: "background")

--- a/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
+++ b/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
@@ -83,7 +83,7 @@ final class SwipeMusicViewController: UIViewController {
     
     private func setupBindings() {
         viewModel.$music
-            .receive(on: RunLoop.main) // 메인 스레드에서 UI 업데이트
+            .receive(on: RunLoop.main)
             .sink { [weak self] music in
                 self?.setupBackgroundColor(by: music?.artwork?.backgroundColor)
             }


### PR DESCRIPTION
## 1. 배경
- @alstn38 님의 선행작업을 받아 진행하였습니다.
- `Song`의 속성 중 `Artwork`에서 `backgroundColor`를 제공하여 사용하였습니다.
```swift
**let backgroundColor: CGColor?     // 이미지의 평균적인 배경색**
```
- #10 참고하여 ViewModel에 음악 정보를 불러왔습니다.
- MVVM 모델 적용했습니다.

## 2. 작업 내용
- [x] SwipMusicViewModel 생성
- [x] SwipMusicViewModel과 SwipMusicViewController 연결
- [x] backGroundColor를 제공해주지 않는 경우, 기본 배경색으로 지정

## 3. 스크린샷
- 배경색을 제공받은 경우 : 배경색 지정 (예시: 로제, 브루노 마스의 아파트)
    <img width=350 src="https://github.com/user-attachments/assets/008da4de-207d-467e-9955-4301f8a10978">
- 배경색을 제공받지 않은 경우 : 기본색 지정
    <img width=350 src="https://github.com/user-attachments/assets/4392d55b-24b0-4bb5-bb27-65a1138838ec">

- 기종별 스크린샷
    |   SE   |   15PRO   | 
    | :-------------: |  :-------------: |
    | <img width=200 src="https://github.com/user-attachments/assets/7a765325-dd23-4322-aad4-0cee858faabd"> | <img width=200 src="https://github.com/user-attachments/assets/20e373ef-2703-4027-9559-1ec789ca88a4"> | 


### 4. Issue 번호
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #16 

## 5. 참고자료
@[MusicKit](https://www.notion.so/MusicKit-136a06a9266280828f84d8d5711fe8fc?pvs=24) 의 음악데이터 타입 을 참고하여 구현하였습니다.