### PR TITLE
feat: 스와이프와 버튼을 동기화 합니다. 

### DIFF
--- a/Molio/Source/Presentation/Common/Component/CircleMenuButton.swift
+++ b/Molio/Source/Presentation/Common/Component/CircleMenuButton.swift
@@ -2,6 +2,15 @@ import UIKit
 
 final class CircleMenuButton: UIButton {
     
+    private var defaultBackgroundColor: UIColor
+    private var highlightBackgroundColor: UIColor
+    
+    override var isHighlighted: Bool {
+        didSet {
+            self.backgroundColor = isHighlighted ? highlightBackgroundColor : defaultBackgroundColor
+        }
+    }
+    
     private let buttonImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
@@ -10,11 +19,14 @@ final class CircleMenuButton: UIButton {
     }()
     
     init(backgroundColor: UIColor,
+         highlightColor: UIColor? = nil,
          buttonSize: CGFloat,
          tintColor: UIColor?,
          buttonImage: UIImage?,
          buttonImageSize: CGSize
     ) {
+        self.defaultBackgroundColor = backgroundColor
+        self.highlightBackgroundColor = highlightColor ?? backgroundColor.withAlphaComponent(0.8)
         super.init(frame: .zero)
         self.translatesAutoresizingMaskIntoConstraints = false
         setupView(backgroundColor: backgroundColor,
@@ -26,6 +38,8 @@ final class CircleMenuButton: UIButton {
     }
     
     required init?(coder: NSCoder) {
+        self.defaultBackgroundColor = .black.withAlphaComponent(0.51)
+        self.highlightBackgroundColor = defaultBackgroundColor.withAlphaComponent(0.8)
         super.init(coder: coder)
     }
     

--- a/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
+++ b/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
@@ -6,6 +6,10 @@ final class SwipeMusicViewController: UIViewController {
     private var input: SwipeMusicViewModel.Input
     private var output: SwipeMusicViewModel.Output
     private let viewDidLoadPublisher = PassthroughSubject<Void, Never>()
+    private let musicCardDidChangeSwipePublisher = PassthroughSubject<CGFloat, Never>()
+    private let musicCardDidFinishSwipePublisher = PassthroughSubject<CGFloat, Never>()
+    private let likeButtonDidTapPublisher = PassthroughSubject<Void, Never>()
+    private let dislikeButtonDidTapPublisher = PassthroughSubject<Void, Never>()
     private var cancellables = Set<AnyCancellable>()
     private let basicBackgroundColor = UIColor(resource: .background)
     
@@ -73,7 +77,13 @@ final class SwipeMusicViewController: UIViewController {
     
     init(viewModel: SwipeMusicViewModel) {
         self.viewModel = viewModel
-        self.input = SwipeMusicViewModel.Input(viewDidLoad: viewDidLoadPublisher.eraseToAnyPublisher())
+        self.input = SwipeMusicViewModel.Input(
+            viewDidLoad: viewDidLoadPublisher.eraseToAnyPublisher(),
+            musicCardDidChangeSwipe: musicCardDidChangeSwipePublisher.eraseToAnyPublisher(),
+            musicCardDidFinishSwipe: musicCardDidFinishSwipePublisher.eraseToAnyPublisher(),
+            likeButtonDidTap: likeButtonDidTapPublisher.eraseToAnyPublisher(),
+            dislikeButtonDidTap: dislikeButtonDidTapPublisher.eraseToAnyPublisher()
+        )
         self.output = viewModel.transform(from: input)
         super.init(nibName: nil, bundle: nil)
     }
@@ -97,7 +107,13 @@ final class SwipeMusicViewController: UIViewController {
                                                       fetchImageUseCase: defaultFetchImageUseCase
         )
         self.viewModel = swipeMusicViewModel
-        self.input = SwipeMusicViewModel.Input(viewDidLoad: viewDidLoadPublisher.eraseToAnyPublisher())
+        self.input = SwipeMusicViewModel.Input(
+            viewDidLoad: viewDidLoadPublisher.eraseToAnyPublisher(),
+            musicCardDidChangeSwipe: musicCardDidChangeSwipePublisher.eraseToAnyPublisher(),
+            musicCardDidFinishSwipe: musicCardDidFinishSwipePublisher.eraseToAnyPublisher(),
+            likeButtonDidTap: likeButtonDidTapPublisher.eraseToAnyPublisher(),
+            dislikeButtonDidTap: dislikeButtonDidTapPublisher.eraseToAnyPublisher()
+        )
         self.output = viewModel.transform(from: input)
         super.init(coder: coder)
     }
@@ -126,6 +142,51 @@ final class SwipeMusicViewController: UIViewController {
                 view.backgroundColor = artworkBackgroundColor
                 musicCardView.configure(music: music)
             }.store(in: &cancellables)
+        
+        output.buttonHighlight
+            .receive(on: RunLoop.main)
+            .sink { [weak self] buttonHighlight in
+                
+            }
+            .store(in: &cancellables)
+        
+        output.musicCardSwipeAnimation
+            .receive(on: RunLoop.main)
+            .sink { [weak self] swipeDirection in
+                guard let self else { return }
+                self.animateMusicCard(direction: swipeDirection)
+            }
+            .store(in: &cancellables)
+    }
+    
+    /// Swipe 동작이 끝나고 MusicCard가 animation되는 메서드
+    private func animateMusicCard(direction: SwipeMusicViewModel.SwipeDirection) {
+        let currentCenter = musicCardView.center
+        let viewCenter = view.center
+        let frameWidth = view.frame.width
+        
+        switch direction {
+        case .left, .right:
+            let movedCenterX = currentCenter.x + direction.rawValue * frameWidth
+            UIView.animate(
+                withDuration: 0.3,
+                animations: { [weak self] in
+                    self?.musicCardView.center = CGPoint(x: movedCenterX, y:currentCenter.y)
+                },
+                completion: { [weak self] _ in
+                self?.refreshMusicCardView()
+            })
+        case .none:
+            UIView.animate(withDuration: 0.3) { [weak self] in
+                self?.musicCardView.center = viewCenter
+            }
+        }
+    }
+    
+    /// Music Card가 다시 refresh되는 메서드
+    private func refreshMusicCardView() {
+        self.musicCardView.removeFromSuperview()
+        self.setupMusicTrackView()
     }
     
     private func addPanGestureToMusicTrack() {
@@ -138,29 +199,11 @@ final class SwipeMusicViewController: UIViewController {
         
         let translation = gesture.translation(in: view)
         card.center = CGPoint(x: view.center.x + translation.x, y: view.center.y + translation.y)
-                
-        if gesture.state == .ended {
-            // 스와이프 임계값 : 카드를 특정 거리 이상 스와이프되었는지를 확인한다.
-            let swipeThreshold: CGFloat = 200
-            
-            // X축으로 이동한 거리가 스와이프 임계값을 넘은 경우
-            if abs(translation.x) > swipeThreshold {
-                let direction: CGFloat = translation.x > 0 ? 1 : -1 // 좌우 판단
-                // 화면 밖으로 이동하는 애니메이션
-                UIView.animate(withDuration: 0.3, animations: {
-                    card.center = CGPoint(x: card.center.x + direction * self.view.frame.width, y: card.center.y)
-                }) { _ in
-                    // 애니메이션 이후 카드 제거 및 새로운 카드 설정
-                    card.removeFromSuperview()
-                    self.setupMusicTrackView()
-                }
-            } else {
-                // 다시 원래 자리로 되돌린다.
-                UIView.animate(withDuration: 0.3) {
-                    card.center = self.view.center
-                    card.transform = .identity
-                }
-            }
+        
+        if gesture.state == .changed {
+            musicCardDidChangeSwipePublisher.send(translation.x)
+        } else if gesture.state == .ended {
+            musicCardDidFinishSwipePublisher.send(translation.x)
         }
     }
     

--- a/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
+++ b/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
@@ -127,6 +127,7 @@ final class SwipeMusicViewController: UIViewController {
         setupMenuButtonView()
         
         setupBindings()
+        setupButtonTarget()
         addPanGestureToMusicTrack()
         
         viewDidLoadPublisher.send()
@@ -194,6 +195,11 @@ final class SwipeMusicViewController: UIViewController {
         musicCardView.addGestureRecognizer(panGesture)
     }
     
+    private func setupButtonTarget() {
+        likeButton.addTarget(self, action: #selector(didTapLikeButton), for: .touchUpInside)
+        dislikeButton.addTarget(self, action: #selector(didTapDislikeButton), for: .touchUpInside)
+    }
+    
     @objc private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
         guard let card = gesture.view else { return }
         
@@ -205,6 +211,14 @@ final class SwipeMusicViewController: UIViewController {
         } else if gesture.state == .ended {
             musicCardDidFinishSwipePublisher.send(translation.x)
         }
+    }
+    
+    @objc private func didTapLikeButton() {
+        likeButtonDidTapPublisher.send()
+    }
+    
+    @objc private func didTapDislikeButton() {
+        dislikeButtonDidTapPublisher.send()
     }
     
     private func setupSelectPlaylistView() {

--- a/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
+++ b/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
@@ -51,25 +51,29 @@ final class SwipeMusicViewController: UIViewController {
     
     private let musicCardView = MusicCardView()
     
-    private let filterButton = CircleMenuButton(backgroundColor: .black.withAlphaComponent(0.2),
+    private let filterButton = CircleMenuButton(backgroundColor: .black.withAlphaComponent(0.51),
+                                                highlightColor: .white.withAlphaComponent(0.51),
                                                 buttonSize: 58.0,
                                                 tintColor: .white,
                                                 buttonImage: UIImage(systemName: "slider.horizontal.3"),
                                                 buttonImageSize: CGSize(width: 21.0, height: 19.0))
     
-    private let dislikeButton = CircleMenuButton(backgroundColor: .black.withAlphaComponent(0.2),
+    private let dislikeButton = CircleMenuButton(backgroundColor: .black.withAlphaComponent(0.51),
+                                                 highlightColor: .white.withAlphaComponent(0.51),
                                                  buttonSize: 66.0,
                                                  tintColor: UIColor(hex: "#FF3D3D"),
                                                  buttonImage: UIImage(systemName: "xmark"),
                                                  buttonImageSize: CGSize(width: 25.0, height: 29.0))
     
-    private let likeButton = CircleMenuButton(backgroundColor: .black.withAlphaComponent(0.2),
+    private let likeButton = CircleMenuButton(backgroundColor: .black.withAlphaComponent(0.51),
+                                              highlightColor: .white.withAlphaComponent(0.51),
                                               buttonSize: 66.0,
                                               tintColor: UIColor(resource: .main),
                                               buttonImage: UIImage(systemName: "heart.fill"),
                                               buttonImageSize: CGSize(width: 30.0, height: 29.0))
     
-    private let myMolioButton = CircleMenuButton(backgroundColor: .black.withAlphaComponent(0.2),
+    private let myMolioButton = CircleMenuButton(backgroundColor: .black.withAlphaComponent(0.51),
+                                                 highlightColor: .white.withAlphaComponent(0.51),
                                                  buttonSize: 58.0,
                                                  tintColor: UIColor(hex: "#FFFAFA"),
                                                  buttonImage: UIImage(systemName: "music.note"),
@@ -147,7 +151,9 @@ final class SwipeMusicViewController: UIViewController {
         output.buttonHighlight
             .receive(on: RunLoop.main)
             .sink { [weak self] buttonHighlight in
-                
+                guard let self else { return }
+                self.likeButton.isHighlighted = buttonHighlight.isLikeHighlighted
+                self.dislikeButton.isHighlighted = buttonHighlight.isDislikeHighlighted
             }
             .store(in: &cancellables)
         

--- a/Molio/Source/Presentation/SwipeMusic/ViewModel/SwipeMusicViewModel.swift
+++ b/Molio/Source/Presentation/SwipeMusic/ViewModel/SwipeMusicViewModel.swift
@@ -5,12 +5,33 @@ import MusicKit
 final class SwipeMusicViewModel: InputOutputViewModel {
     struct Input {
         let viewDidLoad: AnyPublisher<Void, Never>
+        let musicCardDidChangeSwipe: AnyPublisher<CGFloat, Never>
+        let musicCardDidFinishSwipe: AnyPublisher<CGFloat, Never>
+        let likeButtonDidTap: AnyPublisher<Void, Never>
+        let dislikeButtonDidTap: AnyPublisher<Void, Never>
     }
     
     struct Output {
         let currentMusicTrack: AnyPublisher<SwipeMusicTrackModel, Never>
         let isLoading: AnyPublisher<Bool, Never> // TODO: 로딩 UI 구현 및 연결
+        let buttonHighlight: AnyPublisher<ButtonHighlight, Never>
+        let musicCardSwipeAnimation: AnyPublisher<SwipeDirection, Never>
         let error: AnyPublisher<String, Never> // TODO: Error에 따른 알림 UI 구현 및 연결
+    }
+    
+    enum SwipeDirection: CGFloat {
+        case left = -1.0
+        case right = 1.0
+        case none = 0
+    }
+    
+    struct ButtonHighlight {
+        let isLikeHighlighted: Bool
+        let isDislikeHighlighted: Bool
+    }
+    
+    var swipeThreshold: CGFloat {
+        return 200.0
     }
     
     private let musicPlayer = SwipeMusicPlayer()
@@ -19,6 +40,8 @@ final class SwipeMusicViewModel: InputOutputViewModel {
     private var musicsSubject = CurrentValueSubject<[RandomMusic], Never>([])
     private let currentMusicCardPublisher = PassthroughSubject<SwipeMusicTrackModel, Never>()
     private let isLoadingPublisher = PassthroughSubject<Bool, Never>()
+    private let buttonHighlightPublisher = PassthroughSubject<ButtonHighlight, Never>()
+    private let musicCardSwipeAnimationPublisher = PassthroughSubject<SwipeDirection, Never>()
     private let errorPublisher = PassthroughSubject<String, Never>()
     private var cancellables = Set<AnyCancellable>()
     
@@ -43,8 +66,63 @@ final class SwipeMusicViewModel: InputOutputViewModel {
             }
             .store(in: &cancellables)
         
+        input.musicCardDidChangeSwipe
+            .map { [weak self] translation -> ButtonHighlight in
+                guard let self else {
+                    return ButtonHighlight(isLikeHighlighted: false, isDislikeHighlighted: false)
+                }
+                return ButtonHighlight(isLikeHighlighted: translation > self.swipeThreshold,
+                                       isDislikeHighlighted: translation < -self.swipeThreshold
+                )
+            }
+            .sink { [weak self] buttonHighlight in
+                self?.buttonHighlightPublisher.send(buttonHighlight)
+            }
+            .store(in: &cancellables)
+        
+        input.musicCardDidFinishSwipe
+            .map { [weak self] translation -> SwipeDirection in
+                guard let self else { return .none }
+                if translation > self.swipeThreshold {
+                    // TODO: 노래 좋아요에 대한 처리 추가하기
+                    return .right
+                } else if translation < -self.swipeThreshold {
+                    // TODO: 노래 싫어요에 대한 처리 추가하기
+                    return .left
+                } else {
+                    return .none
+                }
+            }
+            .sink { [weak self] swipeDirection in
+                guard let self else { return }
+                self.musicCardSwipeAnimationPublisher.send(swipeDirection)
+                self.buttonHighlightPublisher.send(
+                    ButtonHighlight(isLikeHighlighted: false,
+                                    isDislikeHighlighted: false)
+                )
+            }
+            .store(in: &cancellables)
+        
+        input.likeButtonDidTap
+            .sink { [weak self] _ in
+                guard let self else { return }
+                // TODO: 노래 좋아요에 대한 처리 추가하기
+                self.musicCardSwipeAnimationPublisher.send(.right)
+            }
+            .store(in: &cancellables)
+        
+        input.dislikeButtonDidTap
+            .sink { [weak self] _ in
+                guard let self else { return }
+                // TODO: 노래 싫어요 대한 처리 추가하기
+                self.musicCardSwipeAnimationPublisher.send(.left)
+            }
+            .store(in: &cancellables)
+        
         return Output(currentMusicTrack: currentMusicCardPublisher.eraseToAnyPublisher(),
                       isLoading: isLoadingPublisher.eraseToAnyPublisher(),
+                      buttonHighlight: buttonHighlightPublisher.eraseToAnyPublisher(),
+                      musicCardSwipeAnimation: musicCardSwipeAnimationPublisher.eraseToAnyPublisher(),
                       error: errorPublisher.eraseToAnyPublisher()
         )
     }

--- a/Molio/Source/Presentation/SwipeMusic/ViewModel/SwipeMusicViewModel.swift
+++ b/Molio/Source/Presentation/SwipeMusic/ViewModel/SwipeMusicViewModel.swift
@@ -31,7 +31,7 @@ final class SwipeMusicViewModel: InputOutputViewModel {
     }
     
     var swipeThreshold: CGFloat {
-        return 200.0
+        return 170.0
     }
     
     private let musicPlayer = SwipeMusicPlayer()


### PR DESCRIPTION
## 1. 배경
메인 Swipe하는 부분에서 버튼의 action과 Swipe의 액션이 동일하게 작동해야합니다.
또한, Swipe의 일정 범위 이상 이동하게 될 경우 사용자에게 반응을 해야합니다.

## 2. 작업 내용
- [x] 스와이프의 일정 범위가 넘어간다면 ViewModel에 send()합니다.
- [x] 버튼을 누른다면 카드가 스와이프 되면서 ViewModel에 send() 합니다.
- [x] 스와이프의 일정 범위가 넘어간다면 버튼의 색상이 변경됩니다.
- [x] 스와이프의 일정 범위가 넘어간다면 휴대폰에 진동이 울립니다.


사용자에게 진동을 주는 UIImpactFeedbackGenerator 과정에서 미래에 Deprecated될 가능성이 있는 init을 사용했습니다.
하지만 그렇지 않을 경우 17.5+의 경우만 지원 가능한 init이 남아있기 때문에 이와 같은 결정을 내렸습니다.

[haptic feedback init 정하기](https://www.notion.so/13ea06a92662806a90dac546f74bebb3)

+ 임계값의 범위는 기존에 존재하던 Default값으로 200.0을 줬지만, 휴대폰에서 테스트해보니 생각보다 많이(?)드래그 해야하는 것 같더라구요!
이부분도 함께 실험해보면서 정하면 좋을 것 같아요 !!!

## 3. 스크린샷

|   SE   |   15PRO   | 
| :-------------: |  :-------------: |
| <img width=200 src="https://github.com/user-attachments/assets/ccb9666f-093a-45c5-82d7-eebab154bf1a"> | <img width=200 src="https://github.com/user-attachments/assets/0c58157e-2bcb-404e-89e7-e4407a43b199"> | 


### 4. Issue 번호
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #40 
