### PR TITLE
feat: RandomMusic에서 MolioMusic으로 엔티티 이름 변경하기 (#69)

### DIFF
--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -76,7 +76,7 @@
 		F17369252CDC662A00F6242C /* CircleMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17369242CDC662A00F6242C /* CircleMenuButton.swift */; };
 		F17369292CDC79E100F6242C /* MusicCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17369282CDC79E100F6242C /* MusicCardView.swift */; };
 		F173692D2CDC9CF300F6242C /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F173692C2CDC9CF300F6242C /* UIColor+Extension.swift */; };
-		F173693D2CDF191800F6242C /* RandomMusic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F173693C2CDF191800F6242C /* RandomMusic.swift */; };
+		F173693D2CDF191800F6242C /* MolioMusic.swift in Sources */ = {isa = PBXBuildFile; fileRef = F173693C2CDF191800F6242C /* MolioMusic.swift */; };
 		F173693F2CDF21BC00F6242C /* RecommendedMusicRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F173693E2CDF21BC00F6242C /* RecommendedMusicRepository.swift */; };
 		F17369462CDF24A100F6242C /* FetchRecommendedMusicUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17369452CDF24A100F6242C /* FetchRecommendedMusicUseCase.swift */; };
 		F17369492CDF250200F6242C /* DefaultFetchRecommendedMusicUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17369482CDF250200F6242C /* DefaultFetchRecommendedMusicUseCase.swift */; };
@@ -183,7 +183,7 @@
 		F17369282CDC79E100F6242C /* MusicCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicCardView.swift; sourceTree = "<group>"; };
 		F173692C2CDC9CF300F6242C /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
 		F17369332CDCE31C00F6242C /* MolioTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MolioTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		F173693C2CDF191800F6242C /* RandomMusic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomMusic.swift; sourceTree = "<group>"; };
+		F173693C2CDF191800F6242C /* MolioMusic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MolioMusic.swift; sourceTree = "<group>"; };
 		F173693E2CDF21BC00F6242C /* RecommendedMusicRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendedMusicRepository.swift; sourceTree = "<group>"; };
 		F17369452CDF24A100F6242C /* FetchRecommendedMusicUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchRecommendedMusicUseCase.swift; sourceTree = "<group>"; };
 		F17369482CDF250200F6242C /* DefaultFetchRecommendedMusicUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFetchRecommendedMusicUseCase.swift; sourceTree = "<group>"; };
@@ -462,7 +462,7 @@
 				881622722CE3BAB900E81EA0 /* MusicDeck */,
 				881622732CE3BAC500E81EA0 /* MusicFilterProvider */,
 				881BBCC02CDCF97900010A61 /* RecommendationRequestEntity.swift */,
-				F173693C2CDF191800F6242C /* RandomMusic.swift */,
+				F173693C2CDF191800F6242C /* MolioMusic.swift */,
 				F17369582CDFB73000F6242C /* RGBAColor.swift */,
 			);
 			path = Entity;
@@ -890,7 +890,7 @@
 				F17369572CDFB03E00F6242C /* DefaultMusicKitService.swift in Sources */,
 				2003BA222CDCB31B002CAB3E /* SwipeMusicViewModel.swift in Sources */,
 				F173694B2CDF265900F6242C /* DefaultRecommendedMusicRepository.swift in Sources */,
-				F173693D2CDF191800F6242C /* RandomMusic.swift in Sources */,
+				F173693D2CDF191800F6242C /* MolioMusic.swift in Sources */,
 				20397E702CE5DE56004ED9CE /* PersistenceManager.swift in Sources */,
 				F173691F2CDB995100F6242C /* SwipeMusicViewController.swift in Sources */,
 				2003BA1C2CDB8EE5002CAB3E /* UILabel+Extension.swift in Sources */,

--- a/Molio/Source/Data/DataSource/Network/MusicKitService/DefaultMusicKitService.swift
+++ b/Molio/Source/Data/DataSource/Network/MusicKitService/DefaultMusicKitService.swift
@@ -4,7 +4,7 @@ final class DefaultMusicKitService: MusicKitService {
     /// ISRC 코드로 애플 뮤직 카탈로그 음악을 검색
     ///  - Parameters: 검색할 isrc 문자열
     ///  - Returns: 응답 데이터 (RandomMusic)
-    func getMusic(with isrc: String) async -> RandomMusic? {
+    func getMusic(with isrc: String) async -> MolioMusic? {
         guard checkAuthorizationStatus() else { return nil }
         
         let request = MusicCatalogResourceRequest<Song>(matching: \.isrc, equalTo: isrc)

--- a/Molio/Source/Data/DataSource/Network/MusicKitService/MusicKitService.swift
+++ b/Molio/Source/Data/DataSource/Network/MusicKitService/MusicKitService.swift
@@ -1,3 +1,3 @@
 protocol MusicKitService {
-    func getMusic(with isrc: String) async -> RandomMusic?
+    func getMusic(with isrc: String) async -> MolioMusic?
 }

--- a/Molio/Source/Data/Mapper/SongMapper.swift
+++ b/Molio/Source/Data/Mapper/SongMapper.swift
@@ -1,13 +1,13 @@
 import MusicKit
 
 struct SongMapper {
-    static func toDomain(_ song: Song) -> RandomMusic? {
+    static func toDomain(_ song: Song) -> MolioMusic? {
         guard let isrc = song.isrc,
               let previewAsset = song.previewAssets?.first?.url else {
             return nil
         }
         
-        return RandomMusic(title: song.title,
+        return MolioMusic(title: song.title,
                            artistName: song.artistName,
                            gerneNames: song.genreNames,
                            isrc: isrc,

--- a/Molio/Source/Data/Repository/DefaultRecommendedMusicRepository.swift
+++ b/Molio/Source/Data/Repository/DefaultRecommendedMusicRepository.swift
@@ -9,12 +9,12 @@ struct DefaultRecommendedMusicRepository: RecommendedMusicRepository {
         self.musicKitService = musicKitService
     }
     
-    func fetchMusics(genres: [String]) async throws -> [RandomMusic] {
+    func fetchMusics(genres: [String]) async throws -> [MolioMusic] {
         let musicFilter = MusicFilter(genres: genres)
         let isrcs = try await spotifyAPIService.fetchRecommendedMusicISRCs(musicFilter: musicFilter)
 
-        return try await withThrowingTaskGroup(of: RandomMusic?.self) { group in
-            var musics: [RandomMusic] = []
+        return try await withThrowingTaskGroup(of: MolioMusic?.self) { group in
+            var musics: [MolioMusic] = []
             for isrc in isrcs {
                 group.addTask {
                     return await musicKitService.getMusic(with: isrc)

--- a/Molio/Source/Domain/Entity/MolioMusic.swift
+++ b/Molio/Source/Domain/Entity/MolioMusic.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Swipe 할 수 있는 카드 정보에 표시되는 음악 정보에 대한 Entity입니다.
-struct RandomMusic {
+struct MolioMusic {
     /// 노래 제목
     let title: String
     

--- a/Molio/Source/Domain/Entity/MusicDeck/MusicDeck.swift
+++ b/Molio/Source/Domain/Entity/MusicDeck/MusicDeck.swift
@@ -2,9 +2,9 @@ import Foundation
 import Combine
 
 protocol MusicDeck {
-    var currentMusicTrackModelPublisher: AnyPublisher<RandomMusic?, Never> { get }
+    var currentMusicTrackModelPublisher: AnyPublisher<MolioMusic?, Never> { get }
     
-    var nextMusicTrackModelPublisher: AnyPublisher<RandomMusic?, Never> { get }
+    var nextMusicTrackModelPublisher: AnyPublisher<MolioMusic?, Never> { get }
     
     func likeCurrentMusic()
     

--- a/Molio/Source/Domain/Entity/MusicDeck/RandomMusicDeck.swift
+++ b/Molio/Source/Domain/Entity/MusicDeck/RandomMusicDeck.swift
@@ -3,11 +3,11 @@ import Combine
 // MARK: 프로토콜 요구사항
 
 extension RandomMusicDeck: MusicDeck {
-    var currentMusicTrackModelPublisher: AnyPublisher<RandomMusic?, Never> {
+    var currentMusicTrackModelPublisher: AnyPublisher<MolioMusic?, Never> {
         return musicPublisher(at: 0)
     }
     
-    var nextMusicTrackModelPublisher: AnyPublisher<RandomMusic?, Never> {
+    var nextMusicTrackModelPublisher: AnyPublisher<MolioMusic?, Never> {
         return musicPublisher(at: 1)
     }
 
@@ -33,7 +33,7 @@ final class RandomMusicDeck {
     
     // MARK: 생성자에서 초기화하는 프로퍼티
     
-    var randomMusics: CurrentValueSubject<[RandomMusic], Never>
+    var randomMusics: CurrentValueSubject<[MolioMusic], Never>
     private var musicFilter: CurrentValueSubject<MusicFilter?, Never>
     
     // MARK: Cancellable들
@@ -111,7 +111,7 @@ final class RandomMusicDeck {
     }
     
     
-    private func musicPublisher(at index: Int) -> AnyPublisher<RandomMusic?, Never> {
+    private func musicPublisher(at index: Int) -> AnyPublisher<MolioMusic?, Never> {
         randomMusics
             .compactMap { randomMusics in
                 // 인덱스 범위를 벗어나지 않는지 체크하는 로직이다.

--- a/Molio/Source/Domain/RepositoryInterface/RecommendedMusicRepository.swift
+++ b/Molio/Source/Domain/RepositoryInterface/RecommendedMusicRepository.swift
@@ -2,5 +2,5 @@ protocol RecommendedMusicRepository {
     /// 장르를 통해 Music 정보를 가져옵니다.
     ///  - Parameters: filter할 genres 문자열 배열
     ///  - Returns: 응답 Data
-    func fetchMusics(genres: [String]) async throws -> [RandomMusic]
+    func fetchMusics(genres: [String]) async throws -> [MolioMusic]
 }

--- a/Molio/Source/Domain/UseCase/FetchMusicsUseCase/Implementation/DefaultFetchRecommendedMusicUseCase.swift
+++ b/Molio/Source/Domain/UseCase/FetchMusicsUseCase/Implementation/DefaultFetchRecommendedMusicUseCase.swift
@@ -5,7 +5,7 @@ struct DefaultFetchRecommendedMusicUseCase: FetchRecommendedMusicUseCase {
         self.musicRepository = repository
     }
     
-    func execute(genres: [String]) async throws -> [RandomMusic] {
+    func execute(genres: [String]) async throws -> [MolioMusic] {
         return try await musicRepository.fetchMusics(genres: genres)
     }
 }

--- a/Molio/Source/Domain/UseCase/FetchMusicsUseCase/Protocol/FetchRecommendedMusicUseCase.swift
+++ b/Molio/Source/Domain/UseCase/FetchMusicsUseCase/Protocol/FetchRecommendedMusicUseCase.swift
@@ -1,3 +1,3 @@
 protocol FetchRecommendedMusicUseCase {
-    func execute(genres: [String]) async throws -> [RandomMusic]
+    func execute(genres: [String]) async throws -> [MolioMusic]
 }

--- a/Molio/Source/Presentation/SwipeMusic/Model/SwipeMusicTrackModel.swift
+++ b/Molio/Source/Presentation/SwipeMusic/Model/SwipeMusicTrackModel.swift
@@ -26,7 +26,7 @@ struct SwipeMusicTrackModel {
     /// 앨범에 이미지에 따른 primary 색상
     let primaryTextColor: RGBAColor?
     
-    init(randomMusic: RandomMusic, imageData: Data?) {
+    init(randomMusic: MolioMusic, imageData: Data?) {
         self.title = randomMusic.title
         self.artistName = randomMusic.artistName
         self.gerneNames = Array(randomMusic.gerneNames.prefix(3))

--- a/Molio/Source/Presentation/SwipeMusic/ViewModel/SwipeMusicViewModel.swift
+++ b/Molio/Source/Presentation/SwipeMusic/ViewModel/SwipeMusicViewModel.swift
@@ -170,7 +170,7 @@ final class SwipeMusicViewModel: InputOutputViewModel {
             .store(in: &cancellables)
     }
     
-    private func loadMusicCard(from music: RandomMusic) async throws -> SwipeMusicTrackModel {
+    private func loadMusicCard(from music: MolioMusic) async throws -> SwipeMusicTrackModel {
         guard let imageURL = music.artworkImageURL else {
             return SwipeMusicTrackModel(randomMusic: music, imageData: nil)
         }


### PR DESCRIPTION
# 배경
RandomMusic이라는 엔티티 이름이 내용을 정확하게 표시하지 않았습니다.
앱에서 주로 사용되고 Random과 관련 없다는 의미에서 MolioMusic으로 변경하고자 합니다.
