### PR TITLE
feat: PublishCurrentPlaylistUseCase 프로토콜과 구현체 만들기

### DIFF
--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -57,7 +57,7 @@
 		881BBCC12CDCF97900010A61 /* MusicFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881BBCBF2CDCF97900010A61 /* MusicFilter.swift */; };
 		881BBCC22CDCF97900010A61 /* RecommendationRequestEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881BBCC02CDCF97900010A61 /* RecommendationRequestEntity.swift */; };
 		88F6E4A72CEC852C00739648 /* DefaultPublishCurrentPlaylistUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6E4A62CEC852C00739648 /* DefaultPublishCurrentPlaylistUseCase.swift */; };
-		88F6E4A92CEC88C700739648 /* DefaultPublishCurrentPlaylistUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6E4A82CEC88C700739648 /* DefaultPublishCurrentPlaylistUseCaseTests.swift */; };
+		88F6E4A92CEC88C700739648 /* PublishCurrentPlaylistUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6E4A82CEC88C700739648 /* PublishCurrentPlaylistUseCaseTests.swift */; };
 		88F6E4AB2CEC8B5A00739648 /* PublishCurrentPlaylistUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6E4AA2CEC8B5A00739648 /* PublishCurrentPlaylistUseCase.swift */; };
 		B8046A3C2CE755DB00933704 /* Image+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8046A3B2CE755DB00933704 /* Image+Extension.swift */; };
 		B8046A3E2CE8780000933704 /* MusicFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8046A3D2CE8780000933704 /* MusicFilterViewController.swift */; };
@@ -185,7 +185,7 @@
 		881BBCBF2CDCF97900010A61 /* MusicFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicFilter.swift; sourceTree = "<group>"; };
 		881BBCC02CDCF97900010A61 /* RecommendationRequestEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationRequestEntity.swift; sourceTree = "<group>"; };
 		88F6E4A62CEC852C00739648 /* DefaultPublishCurrentPlaylistUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPublishCurrentPlaylistUseCase.swift; sourceTree = "<group>"; };
-		88F6E4A82CEC88C700739648 /* DefaultPublishCurrentPlaylistUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPublishCurrentPlaylistUseCaseTests.swift; sourceTree = "<group>"; };
+		88F6E4A82CEC88C700739648 /* PublishCurrentPlaylistUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishCurrentPlaylistUseCaseTests.swift; sourceTree = "<group>"; };
 		88F6E4AA2CEC8B5A00739648 /* PublishCurrentPlaylistUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishCurrentPlaylistUseCase.swift; sourceTree = "<group>"; };
 		B8046A3B2CE755DB00933704 /* Image+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Extension.swift"; sourceTree = "<group>"; };
 		B8046A3D2CE8780000933704 /* MusicFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicFilterViewController.swift; sourceTree = "<group>"; };
@@ -797,7 +797,7 @@
 				B8D553F62CDFE623007CCD6D /* NetworkProviderTests.swift */,
 				8816226A2CE3838B00E81EA0 /* DeckTests.swift */,
 				B8D554C12CE32B9A007CCD6D /* SpotifyTokenProviderTests.swift */,
-				88F6E4A82CEC88C700739648 /* DefaultPublishCurrentPlaylistUseCaseTests.swift */,
+				88F6E4A82CEC88C700739648 /* PublishCurrentPlaylistUseCaseTests.swift */,
 				20397E7F2CE5FD0A004ED9CE /* DefaultPlaylistRepositoryTests.swift */,
 				200918432CECA8170058D8C7 /* DefaultCurrentPlaylistRepositoryTests.swift */,
 			);
@@ -1152,7 +1152,7 @@
 				B8D554C22CE32B9A007CCD6D /* SpotifyTokenProviderTests.swift in Sources */,
 				B8D554C42CE33979007CCD6D /* MockNetworkProvider.swift in Sources */,
 				B8046A4D2CEA62D100933704 /* SpotifyAvailableGenreSeedsDTODummy.swift in Sources */,
-				88F6E4A92CEC88C700739648 /* DefaultPublishCurrentPlaylistUseCaseTests.swift in Sources */,
+				88F6E4A92CEC88C700739648 /* PublishCurrentPlaylistUseCaseTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -56,6 +56,9 @@
 		881BBCBE2CDCF95600010A61 /* RecommendationsRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881BBCB82CDCF95600010A61 /* RecommendationsRequestDTO.swift */; };
 		881BBCC12CDCF97900010A61 /* MusicFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881BBCBF2CDCF97900010A61 /* MusicFilter.swift */; };
 		881BBCC22CDCF97900010A61 /* RecommendationRequestEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881BBCC02CDCF97900010A61 /* RecommendationRequestEntity.swift */; };
+		88F6E4A72CEC852C00739648 /* DefaultPublishCurrentPlaylistUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6E4A62CEC852C00739648 /* DefaultPublishCurrentPlaylistUseCase.swift */; };
+		88F6E4A92CEC88C700739648 /* DefaultPublishCurrentPlaylistUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6E4A82CEC88C700739648 /* DefaultPublishCurrentPlaylistUseCaseTests.swift */; };
+		88F6E4AB2CEC8B5A00739648 /* PublishCurrentPlaylistUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F6E4AA2CEC8B5A00739648 /* PublishCurrentPlaylistUseCase.swift */; };
 		B8046A3C2CE755DB00933704 /* Image+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8046A3B2CE755DB00933704 /* Image+Extension.swift */; };
 		B8046A3E2CE8780000933704 /* MusicFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8046A3D2CE8780000933704 /* MusicFilterViewController.swift */; };
 		B8046A442CE9250B00933704 /* MusicGenre.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8046A432CE9250B00933704 /* MusicGenre.swift */; };
@@ -181,6 +184,9 @@
 		881BBCBA2CDCF95600010A61 /* TrackDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackDTO.swift; sourceTree = "<group>"; };
 		881BBCBF2CDCF97900010A61 /* MusicFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicFilter.swift; sourceTree = "<group>"; };
 		881BBCC02CDCF97900010A61 /* RecommendationRequestEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationRequestEntity.swift; sourceTree = "<group>"; };
+		88F6E4A62CEC852C00739648 /* DefaultPublishCurrentPlaylistUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPublishCurrentPlaylistUseCase.swift; sourceTree = "<group>"; };
+		88F6E4A82CEC88C700739648 /* DefaultPublishCurrentPlaylistUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPublishCurrentPlaylistUseCaseTests.swift; sourceTree = "<group>"; };
+		88F6E4AA2CEC8B5A00739648 /* PublishCurrentPlaylistUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishCurrentPlaylistUseCase.swift; sourceTree = "<group>"; };
 		B8046A3B2CE755DB00933704 /* Image+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Extension.swift"; sourceTree = "<group>"; };
 		B8046A3D2CE8780000933704 /* MusicFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicFilterViewController.swift; sourceTree = "<group>"; };
 		B8046A432CE9250B00933704 /* MusicGenre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicGenre.swift; sourceTree = "<group>"; };
@@ -420,6 +426,15 @@
 			path = SpotifyAPIService;
 			sourceTree = "<group>";
 		};
+		88F6E4A52CEC850400739648 /* PublishCurrentPlaylistUseCase */ = {
+			isa = PBXGroup;
+			children = (
+				88F6E4A62CEC852C00739648 /* DefaultPublishCurrentPlaylistUseCase.swift */,
+				88F6E4AA2CEC8B5A00739648 /* PublishCurrentPlaylistUseCase.swift */,
+			);
+			path = PublishCurrentPlaylistUseCase;
+			sourceTree = "<group>";
+		};
 		B8046A3F2CE8950800933704 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -571,6 +586,7 @@
 			isa = PBXGroup;
 			children = (
 				201048552CEA2ACD0015E800 /* CreatePlaylistUsecase */,
+				88F6E4A52CEC850400739648 /* PublishCurrentPlaylistUseCase */,
 				B8046A502CEB93C600933704 /* FetchAvailableGenresUseCase */,
 				F173695E2CE36D4D00F6242C /* FetchImageUsecase */,
 				F17369432CDF248700F6242C /* FetchMusicsUseCase */,
@@ -781,6 +797,7 @@
 				B8D553F62CDFE623007CCD6D /* NetworkProviderTests.swift */,
 				8816226A2CE3838B00E81EA0 /* DeckTests.swift */,
 				B8D554C12CE32B9A007CCD6D /* SpotifyTokenProviderTests.swift */,
+				88F6E4A82CEC88C700739648 /* DefaultPublishCurrentPlaylistUseCaseTests.swift */,
 				20397E7F2CE5FD0A004ED9CE /* DefaultPlaylistRepositoryTests.swift */,
 				200918432CECA8170058D8C7 /* DefaultCurrentPlaylistRepositoryTests.swift */,
 			);
@@ -1043,6 +1060,7 @@
 				F17369542CDFA9FD00F6242C /* CGColorMapper.swift in Sources */,
 				2009183E2CEC9C5B0058D8C7 /* DefaultCurrentPlaylistRepository.swift in Sources */,
 				F17369572CDFB03E00F6242C /* DefaultMusicKitService.swift in Sources */,
+				88F6E4A72CEC852C00739648 /* DefaultPublishCurrentPlaylistUseCase.swift in Sources */,
 				2003BA222CDCB31B002CAB3E /* SwipeMusicViewModel.swift in Sources */,
 				F173694B2CDF265900F6242C /* DefaultRecommendedMusicRepository.swift in Sources */,
 				F173693D2CDF191800F6242C /* MolioMusic.swift in Sources */,
@@ -1072,6 +1090,7 @@
 				20150EC52CEA36B700FC8883 /* Playlist+CoreDataClass.swift in Sources */,
 				20150EC62CEA36B700FC8883 /* Playlist+CoreDataProperties.swift in Sources */,
 				B8D553EE2CDFE2C0007CCD6D /* HTTPResponseStatusCode.swift in Sources */,
+				88F6E4AB2CEC8B5A00739648 /* PublishCurrentPlaylistUseCase.swift in Sources */,
 				B8046A542CEB93F900933704 /* FetchAvailableGenresUseCase.swift in Sources */,
 				B8046A562CEB943B00933704 /* DefaultFetchAvailableGenresUseCase.swift in Sources */,
 				B8D553EA2CDFE271007CCD6D /* EndPoint.swift in Sources */,
@@ -1133,6 +1152,7 @@
 				B8D554C22CE32B9A007CCD6D /* SpotifyTokenProviderTests.swift in Sources */,
 				B8D554C42CE33979007CCD6D /* MockNetworkProvider.swift in Sources */,
 				B8046A4D2CEA62D100933704 /* SpotifyAvailableGenreSeedsDTODummy.swift in Sources */,
+				88F6E4A92CEC88C700739648 /* DefaultPublishCurrentPlaylistUseCaseTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Molio/Source/Domain/UseCase/PublishCurrentPlaylistUseCase/DefaultPublishCurrentPlaylistUseCase.swift
+++ b/Molio/Source/Domain/UseCase/PublishCurrentPlaylistUseCase/DefaultPublishCurrentPlaylistUseCase.swift
@@ -26,5 +26,5 @@ final class DefaultPublishCurrentPlaylistUseCase: PublishCurrentPlaylistUseCase 
 
 protocol CurrentPlaylistRepository {
     var currentPlaylistPublisher: AnyPublisher<UUID?, Never> { get }
-    func setCurrentPlaylsit(_ id: UUID)
+    func setCurrentPlaylist(_ id: UUID)
 }

--- a/Molio/Source/Domain/UseCase/PublishCurrentPlaylistUseCase/DefaultPublishCurrentPlaylistUseCase.swift
+++ b/Molio/Source/Domain/UseCase/PublishCurrentPlaylistUseCase/DefaultPublishCurrentPlaylistUseCase.swift
@@ -1,0 +1,30 @@
+import Combine
+import Foundation
+
+final class DefaultPublishCurrentPlaylistUseCase: PublishCurrentPlaylistUseCase {
+    private let playlistRepository: any PlaylistRepository
+    private let currentPlaylistRepository: any CurrentPlaylistRepository
+    
+    init(
+        playlistRepository: any PlaylistRepository,
+        currentPlaylistRepository: any CurrentPlaylistRepository
+    ) {
+        self.playlistRepository = playlistRepository
+        self.currentPlaylistRepository = currentPlaylistRepository
+    }
+    
+    func execute() -> AnyPublisher<MolioPlaylist?, Never> {
+        currentPlaylistRepository.currentPlaylistPublisher
+            .flatMap { [weak self] playlistUUID in
+                let molioPlaylist = self?.playlistRepository.fetchPlaylist(for: playlistUUID?.uuidString ?? "")
+                
+                return Just(molioPlaylist).eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+}
+
+protocol CurrentPlaylistRepository {
+    var currentPlaylistPublisher: AnyPublisher<UUID?, Never> { get }
+    func setCurrentPlaylsit(_ id: UUID)
+}

--- a/Molio/Source/Domain/UseCase/PublishCurrentPlaylistUseCase/DefaultPublishCurrentPlaylistUseCase.swift
+++ b/Molio/Source/Domain/UseCase/PublishCurrentPlaylistUseCase/DefaultPublishCurrentPlaylistUseCase.swift
@@ -23,8 +23,3 @@ final class DefaultPublishCurrentPlaylistUseCase: PublishCurrentPlaylistUseCase 
             .eraseToAnyPublisher()
     }
 }
-
-protocol CurrentPlaylistRepository {
-    var currentPlaylistPublisher: AnyPublisher<UUID?, Never> { get }
-    func setCurrentPlaylist(_ id: UUID)
-}

--- a/Molio/Source/Domain/UseCase/PublishCurrentPlaylistUseCase/PublishCurrentPlaylistUseCase.swift
+++ b/Molio/Source/Domain/UseCase/PublishCurrentPlaylistUseCase/PublishCurrentPlaylistUseCase.swift
@@ -1,0 +1,5 @@
+import Combine
+
+protocol PublishCurrentPlaylistUseCase {
+    func execute() -> AnyPublisher<MolioPlaylist?, Never>
+}

--- a/MolioTests/DefaultPublishCurrentPlaylistUseCaseTests.swift
+++ b/MolioTests/DefaultPublishCurrentPlaylistUseCaseTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import Molio
+import Combine
+
+final class DefaultPublishCurrentPlaylistUseCaseTests: XCTestCase {
+    private var subscriptions = Set<AnyCancellable>()
+    
+    // `CurrentPlaylistRepository`에서 플레이리스트의 UUID가 변경될 때,
+    // `DefaultPublishCurrentPlaylistUseCase`가 제공하는 퍼블리셔가
+    // 올바르게 업데이트된 플레이리스트를 방출하는지 검증하는 테스트입니다.
+    func testChangePlaylistUUID() {
+        let mockCurrentPlaylistRepository = MockCurrentPlaylistRepository()
+        let mockPlaylistRepository = MockPlaylistRepository()
+        
+        let useCase = DefaultPublishCurrentPlaylistUseCase(playlistRepository: mockPlaylistRepository, currentPlaylistRepository: mockCurrentPlaylistRepository)
+        
+        let currentPlaylistPublisher = useCase.execute()
+        currentPlaylistPublisher.sink { playlist in
+            print("현재 플레이리스트:", playlist?.name ?? "비어있습니다.")
+        }
+        .store(in: &subscriptions)
+        
+        mockCurrentPlaylistRepository.setCurrentPlaylsit(UUID())
+        
+        Thread.sleep(forTimeInterval: 1)
+        
+        mockCurrentPlaylistRepository.setCurrentPlaylsit(UUID())
+        
+        // UUID를 바꿨지만 Playlist가 바뀌어서 저장된다면 성공이다.
+        
+        Thread.sleep(forTimeInterval: 1)
+    }
+}
+
+
+private class MockCurrentPlaylistRepository: CurrentPlaylistRepository {
+    private var currentPlaylistUUID = CurrentValueSubject<UUID?, Never>(nil)
+    
+    var currentPlaylistPublisher: AnyPublisher<UUID?, Never> {
+        currentPlaylistUUID.eraseToAnyPublisher()
+    }
+    
+    func setCurrentPlaylsit(_ id: UUID) {
+        currentPlaylistUUID.send(id)
+    }
+}
+
+private class MockPlaylistRepository: PlaylistRepository {
+    private var playlists = CurrentValueSubject<[MolioPlaylist], Never>([])
+    
+    var playlistsPublisher: AnyPublisher<[MolioPlaylist], Never> {
+        playlists.eraseToAnyPublisher()
+    }
+    
+    func addMusic(isrc: String, to playlistName: String) {
+    }
+    
+    func deleteMusic(isrc: String, in playlistName: String) {
+
+    }
+    
+    func deletePlaylist(_ playlistName: String) {
+        
+    }
+    
+    func fetchPlaylist(for name: String) -> MolioPlaylist? {
+        MolioPlaylist(id: UUID(), name: name, createdAt: Date.now, musicISRCs: [], filters: [])
+    }
+    
+    func fetchPlaylists() -> [MolioPlaylist]? {
+        []
+    }
+    
+    func moveMusic(isrc: String, in playlistName: String, fromIndex: Int, toIndex: Int) {
+        
+    }
+    
+    func saveNewPlaylist(_ playlistName: String) {
+        
+    }
+}

--- a/MolioTests/PublishCurrentPlaylistUseCaseTests.swift
+++ b/MolioTests/PublishCurrentPlaylistUseCaseTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Molio
 import Combine
 
-final class DefaultPublishCurrentPlaylistUseCaseTests: XCTestCase {
+final class PublishCurrentPlaylistUseCaseTests: XCTestCase {
     private var subscriptions = Set<AnyCancellable>()
     
     // `CurrentPlaylistRepository`에서 플레이리스트의 UUID가 변경될 때,
@@ -32,10 +32,9 @@ final class DefaultPublishCurrentPlaylistUseCaseTests: XCTestCase {
         
         mockCurrentPlaylistRepository.setCurrentPlaylist(UUID())
         
-        if playlists.count >= 2 {
-            XCTAssertEqual(playlists[0]?.name, nil)
-            XCTAssertEqual(playlists[0]?.name, playlists[1]?.name)
-            XCTAssertEqual(playlists[1]?.name, playlists[2]?.name)
+        if playlists.count >= 3 {
+            XCTAssertNotEqual(playlists[0]?.name, playlists[1]?.name)
+            XCTAssertNotEqual(playlists[1]?.name, playlists[2]?.name)
         } else {
             XCTFail("플레이리스트가 변경되지 않았습니다.")
         }
@@ -44,6 +43,10 @@ final class DefaultPublishCurrentPlaylistUseCaseTests: XCTestCase {
 
 
 private class MockCurrentPlaylistRepository: CurrentPlaylistRepository {
+    func setDefaultPlaylist(_ id: UUID) throws {
+        
+    }
+    
     private var currentPlaylistUUID = CurrentValueSubject<UUID?, Never>(nil)
     
     var currentPlaylistPublisher: AnyPublisher<UUID?, Never> {


### PR DESCRIPTION
# 배경
현재 위치한 플레이리스트의 값에 대한 퍼블리셔가 필요합니다.
예를 들면 앞으로 MusicDeck에서 사용합니다.

# 수정 내용
- PublishCurrentPlaylistUseCase 프로토콜 정의하기
- DefaultPublishCurrentPlaylistUseCase 클래스 구현하기
- 테스트 코드 작성하기

# 스크린샷
<img width="445" alt="image" src="https://github.com/user-attachments/assets/393a7483-21f5-4954-b1bd-6b0934fe13c7">

# 관련 이슈
#73 