### PR TITLE
feat: PublishAllMusicInCurrentPlaylistUseCase 프로토콜 정의와 구현체 작성 (#82)

### DIFF
--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		881BBCBE2CDCF95600010A61 /* RecommendationsRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881BBCB82CDCF95600010A61 /* RecommendationsRequestDTO.swift */; };
 		881BBCC12CDCF97900010A61 /* MusicFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881BBCBF2CDCF97900010A61 /* MusicFilter.swift */; };
 		881BBCC22CDCF97900010A61 /* RecommendationRequestEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881BBCC02CDCF97900010A61 /* RecommendationRequestEntity.swift */; };
+		88C8B5EB2CEF1E130079ACB5 /* PublishAllMusicInCurrentPlaylistUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C8B5EA2CEF1E130079ACB5 /* PublishAllMusicInCurrentPlaylistUseCase.swift */; };
+		88C8B5ED2CEF1E240079ACB5 /* DefaultPublishAllMusicInCurrentPlaylistUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C8B5EC2CEF1E240079ACB5 /* DefaultPublishAllMusicInCurrentPlaylistUseCase.swift */; };
 		88E483492CEDDD4A003D624E /* PlaylistDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E483462CEDDD4A003D624E /* PlaylistDetailView.swift */; };
 		88E4834A2CEDDD4A003D624E /* AudioPlayerControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E483472CEDDD4A003D624E /* AudioPlayerControlView.swift */; };
 		88E4834B2CEDDD4A003D624E /* MusicListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E483482CEDDD4A003D624E /* MusicListView.swift */; };
@@ -211,6 +213,8 @@
 		881BBCBA2CDCF95600010A61 /* TrackDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackDTO.swift; sourceTree = "<group>"; };
 		881BBCBF2CDCF97900010A61 /* MusicFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicFilter.swift; sourceTree = "<group>"; };
 		881BBCC02CDCF97900010A61 /* RecommendationRequestEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationRequestEntity.swift; sourceTree = "<group>"; };
+		88C8B5EA2CEF1E130079ACB5 /* PublishAllMusicInCurrentPlaylistUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishAllMusicInCurrentPlaylistUseCase.swift; sourceTree = "<group>"; };
+		88C8B5EC2CEF1E240079ACB5 /* DefaultPublishAllMusicInCurrentPlaylistUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPublishAllMusicInCurrentPlaylistUseCase.swift; sourceTree = "<group>"; };
 		88E483452CEDDD4A003D624E /* MusicCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicCellView.swift; sourceTree = "<group>"; };
 		88E483462CEDDD4A003D624E /* PlaylistDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistDetailView.swift; sourceTree = "<group>"; };
 		88E483472CEDDD4A003D624E /* AudioPlayerControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayerControlView.swift; sourceTree = "<group>"; };
@@ -511,6 +515,15 @@
 			path = SpotifyAPIService;
 			sourceTree = "<group>";
 		};
+		88C8B5E92CEF1DF60079ACB5 /* PublishAllMusicInCurrentPlaylistUseCase */ = {
+			isa = PBXGroup;
+			children = (
+				88C8B5EA2CEF1E130079ACB5 /* PublishAllMusicInCurrentPlaylistUseCase.swift */,
+				88C8B5EC2CEF1E240079ACB5 /* DefaultPublishAllMusicInCurrentPlaylistUseCase.swift */,
+			);
+			path = PublishAllMusicInCurrentPlaylistUseCase;
+			sourceTree = "<group>";
+		};
 		88E483442CEDDD3C003D624E /* PlaylistDetail */ = {
 			isa = PBXGroup;
 			children = (
@@ -682,6 +695,7 @@
 		B80970812CDB4472007BC3C4 /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
+				88C8B5E92CEF1DF60079ACB5 /* PublishAllMusicInCurrentPlaylistUseCase */,
 				2075FEC22CECDE0F009834BE /* ChangeCurrentPlaylistIUseCase */,
 				F1E4059F2CEC9E4100533701 /* SignInAppleUseCase */,
 				201048552CEA2ACD0015E800 /* CreatePlaylistUsecase */,
@@ -1226,6 +1240,7 @@
 				F1E405A52CECA19200533701 /* DefaultSignInAppleUseCase.swift in Sources */,
 				F173693D2CDF191800F6242C /* MolioMusic.swift in Sources */,
 				20397E702CE5DE56004ED9CE /* PersistenceManager.swift in Sources */,
+				88C8B5ED2CEF1E240079ACB5 /* DefaultPublishAllMusicInCurrentPlaylistUseCase.swift in Sources */,
 				F173691F2CDB995100F6242C /* SwipeMusicViewController.swift in Sources */,
 				2003BA1C2CDB8EE5002CAB3E /* UILabel+Extension.swift in Sources */,
 				F17369682CE36E8F00F6242C /* DefaultImageRepository.swift in Sources */,
@@ -1266,6 +1281,7 @@
 				20397E6A2CE5DCDD004ED9CE /* MolioModel.xcdatamodeld in Sources */,
 				F17369722CE3716100F6242C /* DefaultImageFetchService.swift in Sources */,
 				2003BA012CDB7498002CAB3E /* PretendardFontName.swift in Sources */,
+				88C8B5EB2CEF1E130079ACB5 /* PublishAllMusicInCurrentPlaylistUseCase.swift in Sources */,
 				B8D553E82CDFE25C007CCD6D /* NetworkProvider.swift in Sources */,
 				881BBCBB2CDCF95600010A61 /* TrackDTO.swift in Sources */,
 				881BBCBC2CDCF95600010A61 /* RecommendationsResponseDTO.swift in Sources */,

--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		881BBCC22CDCF97900010A61 /* RecommendationRequestEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881BBCC02CDCF97900010A61 /* RecommendationRequestEntity.swift */; };
 		88C8B5EB2CEF1E130079ACB5 /* PublishAllMusicInCurrentPlaylistUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C8B5EA2CEF1E130079ACB5 /* PublishAllMusicInCurrentPlaylistUseCase.swift */; };
 		88C8B5ED2CEF1E240079ACB5 /* DefaultPublishAllMusicInCurrentPlaylistUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C8B5EC2CEF1E240079ACB5 /* DefaultPublishAllMusicInCurrentPlaylistUseCase.swift */; };
+		88C8B5F32CEF296A0079ACB5 /* PublishAllMusicInCurrentPlaylistUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C8B5F22CEF296A0079ACB5 /* PublishAllMusicInCurrentPlaylistUseCaseTests.swift */; };
 		88E483492CEDDD4A003D624E /* PlaylistDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E483462CEDDD4A003D624E /* PlaylistDetailView.swift */; };
 		88E4834A2CEDDD4A003D624E /* AudioPlayerControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E483472CEDDD4A003D624E /* AudioPlayerControlView.swift */; };
 		88E4834B2CEDDD4A003D624E /* MusicListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E483482CEDDD4A003D624E /* MusicListView.swift */; };
@@ -215,6 +216,7 @@
 		881BBCC02CDCF97900010A61 /* RecommendationRequestEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendationRequestEntity.swift; sourceTree = "<group>"; };
 		88C8B5EA2CEF1E130079ACB5 /* PublishAllMusicInCurrentPlaylistUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishAllMusicInCurrentPlaylistUseCase.swift; sourceTree = "<group>"; };
 		88C8B5EC2CEF1E240079ACB5 /* DefaultPublishAllMusicInCurrentPlaylistUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPublishAllMusicInCurrentPlaylistUseCase.swift; sourceTree = "<group>"; };
+		88C8B5F22CEF296A0079ACB5 /* PublishAllMusicInCurrentPlaylistUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishAllMusicInCurrentPlaylistUseCaseTests.swift; sourceTree = "<group>"; };
 		88E483452CEDDD4A003D624E /* MusicCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicCellView.swift; sourceTree = "<group>"; };
 		88E483462CEDDD4A003D624E /* PlaylistDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistDetailView.swift; sourceTree = "<group>"; };
 		88E483472CEDDD4A003D624E /* AudioPlayerControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayerControlView.swift; sourceTree = "<group>"; };
@@ -925,6 +927,7 @@
 				8816226A2CE3838B00E81EA0 /* DeckTests.swift */,
 				B8D554C12CE32B9A007CCD6D /* SpotifyTokenProviderTests.swift */,
 				88F6E4A82CEC88C700739648 /* PublishCurrentPlaylistUseCaseTests.swift */,
+				88C8B5F22CEF296A0079ACB5 /* PublishAllMusicInCurrentPlaylistUseCaseTests.swift */,
 				20397E7F2CE5FD0A004ED9CE /* DefaultPlaylistRepositoryTests.swift */,
 				200918432CECA8170058D8C7 /* DefaultCurrentPlaylistRepositoryTests.swift */,
 			);
@@ -1343,6 +1346,7 @@
 				B8D554C22CE32B9A007CCD6D /* SpotifyTokenProviderTests.swift in Sources */,
 				B8D554C42CE33979007CCD6D /* MockNetworkProvider.swift in Sources */,
 				B8046A4D2CEA62D100933704 /* SpotifyAvailableGenreSeedsDTODummy.swift in Sources */,
+				88C8B5F32CEF296A0079ACB5 /* PublishAllMusicInCurrentPlaylistUseCaseTests.swift in Sources */,
 				88F6E4A92CEC88C700739648 /* PublishCurrentPlaylistUseCaseTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Molio/Source/App/AppDelegate.swift
+++ b/Molio/Source/App/AppDelegate.swift
@@ -26,6 +26,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         container.register(CreatePlaylistUseCase.self, dependency: DefaultCreatePlaylistUseCase())
         container.register(ChangeCurrentPlaylistUseCase.self, dependency: DefaultChangeCurrentPlaylistUseCase())
         container.register(PublishCurrentPlaylistUseCase.self, dependency: DefaultPublishCurrentPlaylistUseCase())
+        container.register(PublishAllMusicInCurrentPlaylistUseCase.self, dependency: DefaultPublishAllMusicInCurrentPlaylistUseCase())
         
         FirebaseApp.configure()
         return true

--- a/Molio/Source/Domain/UseCase/PublishAllMusicInCurrentPlaylistUseCase/DefaultPublishAllMusicInCurrentPlaylistUseCase.swift
+++ b/Molio/Source/Domain/UseCase/PublishAllMusicInCurrentPlaylistUseCase/DefaultPublishAllMusicInCurrentPlaylistUseCase.swift
@@ -1,0 +1,34 @@
+import Combine
+
+final class DefaultPublishAllMusicInCurrentPlaylistUseCase: PublishAllMusicInCurrentPlaylistUseCase {
+    
+    private let allMusicPublisher: AnyPublisher<[MolioMusic], Never>
+    
+    init(
+        publishCurrentPlaylistUseCase: any PublishCurrentPlaylistUseCase = DIContainer.shared.resolve(),
+        musicKitService: any MusicKitService = DIContainer.shared.resolve()
+    ) {
+        let publisher = publishCurrentPlaylistUseCase
+            .execute()
+            .flatMap { molioPlaylist in
+                return Future<[MolioMusic], Never> { promise in
+                    guard let musicISRCs = molioPlaylist?.musicISRCs else {
+                        return promise(.success([]))
+                    }
+
+                    Task {
+                        let molioMusics = await musicKitService.getMusic(with: musicISRCs)
+
+                        return promise(.success(molioMusics))
+                    }
+                }
+            }
+            .eraseToAnyPublisher()
+        
+        self.allMusicPublisher = publisher
+    }
+    
+    func execute() -> AnyPublisher<[MolioMusic], Never> {
+        allMusicPublisher
+    }
+}

--- a/Molio/Source/Domain/UseCase/PublishAllMusicInCurrentPlaylistUseCase/PublishAllMusicInCurrentPlaylistUseCase.swift
+++ b/Molio/Source/Domain/UseCase/PublishAllMusicInCurrentPlaylistUseCase/PublishAllMusicInCurrentPlaylistUseCase.swift
@@ -1,0 +1,5 @@
+import Combine
+
+protocol PublishAllMusicInCurrentPlaylistUseCase {
+    func execute() -> AnyPublisher<[MolioMusic], Never>
+}

--- a/MolioTests/PublishAllMusicInCurrentPlaylistUseCaseTests.swift
+++ b/MolioTests/PublishAllMusicInCurrentPlaylistUseCaseTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import Molio
+import Combine
+
+final class PublishAllMusicInCurrentPlaylistUseCaseTests: XCTestCase {
+    private let examplePlaylist = MolioPlaylist(
+        id: UUID(),
+        name: "My Favorite Songs",
+        createdAt: Date(),
+        musicISRCs: ["USUM72014967", "USUM72014968"],
+        filters: ["Pop", "2020s"]
+    )
+    private let newPlaylist = MolioPlaylist(
+        id: UUID(),
+        name: "Chill Vibes",
+        createdAt: Date(),
+        musicISRCs: ["USUM72014969", "USUM72014970"],
+        filters: ["Chill", "Acoustic"]
+    )
+
+    private var subscriptions = Set<AnyCancellable>()
+    
+    func testPlaylistMusicsWhenPlaylistChanged() {
+        let mockPublishCurrentPlaylistUseCase = MockPublishCurrentPlaylistUseCase()
+        
+        let useCase = DefaultPublishAllMusicInCurrentPlaylistUseCase(publishCurrentPlaylistUseCase: mockPublishCurrentPlaylistUseCase, musicKitService: DefaultMusicKitService())
+        
+        let expectation1 = expectation(description: "First playlist emitted")
+        let expectation2 = expectation(description: "Second playlist emitted")
+
+        var emittedMusicISRCs: [[String]] = []
+        
+        mockPublishCurrentPlaylistUseCase
+            .execute()
+            .receive(on: DispatchQueue.main) // Ensure updates are on the main thread
+            .sink { playlist in
+                emittedMusicISRCs.append(playlist?.musicISRCs ?? [])
+                
+                switch emittedMusicISRCs.count {
+                case 1:
+                    expectation1.fulfill()
+                case 2:
+                    expectation2.fulfill()
+                default:
+                    break
+                }
+                // Fulfill expectations based on the number of emitted playlists
+            }
+            .store(in: &subscriptions)
+        mockPublishCurrentPlaylistUseCase.updatePlaylist(examplePlaylist)
+        mockPublishCurrentPlaylistUseCase.updatePlaylist(newPlaylist)
+        // Wait for all expectations to be fulfilled within a timeout
+        wait(for: [expectation1, expectation2], timeout: 2.0)
+        
+        print(emittedMusicISRCs)
+        
+        // Now perform your assertions
+        XCTAssertNotEqual(emittedMusicISRCs[0], emittedMusicISRCs[1], "First and second playlists should have different music ISRCs.")
+    }
+}
+
+
+// Mock 구현을 위한 클래스
+private class MockPublishCurrentPlaylistUseCase: PublishCurrentPlaylistUseCase {
+    
+    // 원하는 MolioPlaylist을 설정할 수 있는 프로퍼티
+    var mockPlaylist: MolioPlaylist?
+    
+    // 데이터를 발행하기 위한 퍼블리셔
+    private var subject: CurrentValueSubject<MolioPlaylist?, Never>
+    
+    // 초기화 시 mockPlaylist를 설정하고 subject를 초기화
+    init(mockPlaylist: MolioPlaylist? = nil) {
+        self.mockPlaylist = mockPlaylist
+        self.subject = CurrentValueSubject<MolioPlaylist?, Never>(mockPlaylist)
+    }
+    
+    // 프로토콜의 execute 메서드 구현
+    func execute() -> AnyPublisher<MolioPlaylist?, Never> {
+        return subject.eraseToAnyPublisher()
+    }
+    
+    // 테스트 중에 mockPlaylist를 업데이트할 수 있는 메서드
+    func updatePlaylist(_ playlist: MolioPlaylist?) {
+        self.mockPlaylist = playlist
+        subject.send(playlist)
+    }
+}


### PR DESCRIPTION
# 내용
- 현재 플레이리스트의 노래들의 배열을 구독하도록 퍼블리셔를 제공하는 유즈케이스 입니다.

# 스크린샷
<img width="490" alt="image" src="https://github.com/user-attachments/assets/228120af-7c5e-4532-a271-68a622a3b8d5">


# 관련 이슈
#82 