### PR TITLE
feat: PublishAllPlaylistTitleUseCase 구현

### DIFF
--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -63,6 +63,9 @@
 		88C8B5EB2CEF1E130079ACB5 /* PublishAllMusicInCurrentPlaylistUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C8B5EA2CEF1E130079ACB5 /* PublishAllMusicInCurrentPlaylistUseCase.swift */; };
 		88C8B5ED2CEF1E240079ACB5 /* DefaultPublishAllMusicInCurrentPlaylistUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C8B5EC2CEF1E240079ACB5 /* DefaultPublishAllMusicInCurrentPlaylistUseCase.swift */; };
 		88C8B5F32CEF296A0079ACB5 /* PublishAllMusicInCurrentPlaylistUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C8B5F22CEF296A0079ACB5 /* PublishAllMusicInCurrentPlaylistUseCaseTests.swift */; };
+		88C8B5F52CEF30B80079ACB5 /* PublishAllPlaylistTitleUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C8B5F42CEF30B80079ACB5 /* PublishAllPlaylistTitleUseCase.swift */; };
+		88C8B5F72CEF30C60079ACB5 /* DefaultPublishAllPlaylistTitleUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C8B5F62CEF30C60079ACB5 /* DefaultPublishAllPlaylistTitleUseCase.swift */; };
+		88C8B5F92CEF32080079ACB5 /* PublishAllPlaylistTitleUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C8B5F82CEF32080079ACB5 /* PublishAllPlaylistTitleUseCaseTests.swift */; };
 		88E483492CEDDD4A003D624E /* PlaylistDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E483462CEDDD4A003D624E /* PlaylistDetailView.swift */; };
 		88E4834A2CEDDD4A003D624E /* AudioPlayerControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E483472CEDDD4A003D624E /* AudioPlayerControlView.swift */; };
 		88E4834B2CEDDD4A003D624E /* MusicListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E483482CEDDD4A003D624E /* MusicListView.swift */; };
@@ -217,6 +220,9 @@
 		88C8B5EA2CEF1E130079ACB5 /* PublishAllMusicInCurrentPlaylistUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishAllMusicInCurrentPlaylistUseCase.swift; sourceTree = "<group>"; };
 		88C8B5EC2CEF1E240079ACB5 /* DefaultPublishAllMusicInCurrentPlaylistUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPublishAllMusicInCurrentPlaylistUseCase.swift; sourceTree = "<group>"; };
 		88C8B5F22CEF296A0079ACB5 /* PublishAllMusicInCurrentPlaylistUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishAllMusicInCurrentPlaylistUseCaseTests.swift; sourceTree = "<group>"; };
+		88C8B5F42CEF30B80079ACB5 /* PublishAllPlaylistTitleUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishAllPlaylistTitleUseCase.swift; sourceTree = "<group>"; };
+		88C8B5F62CEF30C60079ACB5 /* DefaultPublishAllPlaylistTitleUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPublishAllPlaylistTitleUseCase.swift; sourceTree = "<group>"; };
+		88C8B5F82CEF32080079ACB5 /* PublishAllPlaylistTitleUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishAllPlaylistTitleUseCaseTests.swift; sourceTree = "<group>"; };
 		88E483452CEDDD4A003D624E /* MusicCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicCellView.swift; sourceTree = "<group>"; };
 		88E483462CEDDD4A003D624E /* PlaylistDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistDetailView.swift; sourceTree = "<group>"; };
 		88E483472CEDDD4A003D624E /* AudioPlayerControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayerControlView.swift; sourceTree = "<group>"; };
@@ -705,6 +711,8 @@
 				B8046A502CEB93C600933704 /* FetchAvailableGenresUseCase */,
 				F173695E2CE36D4D00F6242C /* FetchImageUsecase */,
 				F17369432CDF248700F6242C /* FetchMusicsUseCase */,
+				88C8B5F42CEF30B80079ACB5 /* PublishAllPlaylistTitleUseCase.swift */,
+				88C8B5F62CEF30C60079ACB5 /* DefaultPublishAllPlaylistTitleUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -926,6 +934,7 @@
 				B8D553F62CDFE623007CCD6D /* NetworkProviderTests.swift */,
 				8816226A2CE3838B00E81EA0 /* DeckTests.swift */,
 				B8D554C12CE32B9A007CCD6D /* SpotifyTokenProviderTests.swift */,
+				88C8B5F82CEF32080079ACB5 /* PublishAllPlaylistTitleUseCaseTests.swift */,
 				88F6E4A82CEC88C700739648 /* PublishCurrentPlaylistUseCaseTests.swift */,
 				88C8B5F22CEF296A0079ACB5 /* PublishAllMusicInCurrentPlaylistUseCaseTests.swift */,
 				20397E7F2CE5FD0A004ED9CE /* DefaultPlaylistRepositoryTests.swift */,
@@ -1241,6 +1250,7 @@
 				2003BA222CDCB31B002CAB3E /* SwipeMusicViewModel.swift in Sources */,
 				F173694B2CDF265900F6242C /* DefaultRecommendedMusicRepository.swift in Sources */,
 				F1E405A52CECA19200533701 /* DefaultSignInAppleUseCase.swift in Sources */,
+				88C8B5F72CEF30C60079ACB5 /* DefaultPublishAllPlaylistTitleUseCase.swift in Sources */,
 				F173693D2CDF191800F6242C /* MolioMusic.swift in Sources */,
 				20397E702CE5DE56004ED9CE /* PersistenceManager.swift in Sources */,
 				88C8B5ED2CEF1E240079ACB5 /* DefaultPublishAllMusicInCurrentPlaylistUseCase.swift in Sources */,
@@ -1273,6 +1283,7 @@
 				B8D553EE2CDFE2C0007CCD6D /* HTTPResponseStatusCode.swift in Sources */,
 				88F6E4AB2CEC8B5A00739648 /* PublishCurrentPlaylistUseCase.swift in Sources */,
 				B8046A542CEB93F900933704 /* FetchAvailableGenresUseCase.swift in Sources */,
+				88C8B5F52CEF30B80079ACB5 /* PublishAllPlaylistTitleUseCase.swift in Sources */,
 				2075FEC12CECDDC0009834BE /* CreatePlaylistViewModel.swift in Sources */,
 				B8046A562CEB943B00933704 /* DefaultFetchAvailableGenresUseCase.swift in Sources */,
 				2075FEC82CECDF4D009834BE /* CoreDataError.swift in Sources */,
@@ -1340,6 +1351,7 @@
 				20397E802CE5FD0A004ED9CE /* DefaultPlaylistRepositoryTests.swift in Sources */,
 				B8D554872CE0F41F007CCD6D /* NetworkProviderTests.swift in Sources */,
 				200918442CECA8170058D8C7 /* DefaultCurrentPlaylistRepositoryTests.swift in Sources */,
+				88C8B5F92CEF32080079ACB5 /* PublishAllPlaylistTitleUseCaseTests.swift in Sources */,
 				B8D554862CE0F417007CCD6D /* MockURLProtocol.swift in Sources */,
 				B8D554852CE0F411007CCD6D /* SpotifyAccessTokenResponseDTODummy.swift in Sources */,
 				B8D554802CE0F152007CCD6D /* RecommendationsResponseDTODummy.swift in Sources */,

--- a/Molio.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Molio.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7a659320054cfa34627e8bbe1c40d5e4d9899fed9266cb740ba4c3afa7fb4b0a",
+  "originHash" : "fc494ae213b352fc476555c2b7911ae520604e8a19ab8432fc783acaba846b4e",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/Molio/Source/App/AppDelegate.swift
+++ b/Molio/Source/App/AppDelegate.swift
@@ -27,6 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         container.register(ChangeCurrentPlaylistUseCase.self, dependency: DefaultChangeCurrentPlaylistUseCase())
         container.register(PublishCurrentPlaylistUseCase.self, dependency: DefaultPublishCurrentPlaylistUseCase())
         container.register(PublishAllMusicInCurrentPlaylistUseCase.self, dependency: DefaultPublishAllMusicInCurrentPlaylistUseCase())
+        container.register(PublishAllPlaylistTitleUseCase.self, dependency: DefaultPublishAllPlaylistTitleUseCase())
         
         FirebaseApp.configure()
         return true

--- a/Molio/Source/Domain/UseCase/DefaultPublishAllPlaylistTitleUseCase.swift
+++ b/Molio/Source/Domain/UseCase/DefaultPublishAllPlaylistTitleUseCase.swift
@@ -1,0 +1,19 @@
+import Combine
+
+final class DefaultPublishAllPlaylistTitleUseCase: PublishAllPlaylistTitleUseCase {
+    private var subsciptions: Set<AnyCancellable> = []
+    
+    private let allPlaylistTitlePublisher: AnyPublisher<[String], Never>
+    
+    init(playlistRepository: any PlaylistRepository) {
+        self.allPlaylistTitlePublisher = playlistRepository.playlistsPublisher
+            .flatMap { playlist in
+                Just(playlist.map { $0.name })
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    func execute() -> AnyPublisher<[String], Never> {
+        allPlaylistTitlePublisher
+    }
+}

--- a/Molio/Source/Domain/UseCase/DefaultPublishAllPlaylistTitleUseCase.swift
+++ b/Molio/Source/Domain/UseCase/DefaultPublishAllPlaylistTitleUseCase.swift
@@ -5,7 +5,9 @@ final class DefaultPublishAllPlaylistTitleUseCase: PublishAllPlaylistTitleUseCas
     
     private let allPlaylistTitlePublisher: AnyPublisher<[String], Never>
     
-    init(playlistRepository: any PlaylistRepository) {
+    init(
+        playlistRepository: any PlaylistRepository = DIContainer.shared.resolve()
+    ) {
         self.allPlaylistTitlePublisher = playlistRepository.playlistsPublisher
             .flatMap { playlist in
                 Just(playlist.map { $0.name })

--- a/Molio/Source/Domain/UseCase/PublishAllPlaylistTitleUseCase.swift
+++ b/Molio/Source/Domain/UseCase/PublishAllPlaylistTitleUseCase.swift
@@ -1,0 +1,5 @@
+import Combine
+
+protocol PublishAllPlaylistTitleUseCase {
+    func execute() -> AnyPublisher<[String], Never>
+}

--- a/MolioTests/PublishAllPlaylistTitleUseCaseTests.swift
+++ b/MolioTests/PublishAllPlaylistTitleUseCaseTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+@testable import Molio
+import Combine
+
+final class PublishAllPlaylistTitleUseCaseTests: XCTestCase {
+    
+    func testAddNewPlaylistAndSeeIfItIsPublished() async throws {
+        var subscriptions = Set<AnyCancellable>()
+
+        // 레포지토리에 플레이리스트를 만들고 expectation 다음게 하나가 추가 되었는지 맞는지 확인
+        let mockPlaylistRepository = MockPlaylistRepository()
+        
+        let useCase = DefaultPublishAllPlaylistTitleUseCase(
+            playlistRepository: mockPlaylistRepository
+        )
+        
+        let expectation1 = expectation(description: "Initial empty playlist emitted")
+        let expectation2 = expectation(description: "New playlist title emitted")
+        
+        var emittedPlaylistTitles: [[String]] = []
+        
+        useCase.execute()
+            .receive(on: DispatchQueue.main) // Ensure updates are on the main thread
+            .sink { titles in
+                emittedPlaylistTitles.append(titles)
+                
+                // Fulfill expectations based on the number of emitted titles
+                switch emittedPlaylistTitles.count {
+                case 1:
+                    expectation1.fulfill()
+                case 2:
+                    expectation2.fulfill()
+                default:
+                    break
+                }
+            }
+            .store(in: &subscriptions)
+        
+        // Initially, the repository has no playlists
+        // Fulfill the first expectation
+        // (Already handled by the publisher emitting the initial state)
+        
+        // Add a new playlist
+        let newPlaylistName = "My New Playlist"
+        
+        Task {
+            let _ = try await mockPlaylistRepository.saveNewPlaylist(newPlaylistName)
+
+            let _ = try await mockPlaylistRepository.saveNewPlaylist(newPlaylistName)
+
+        }
+
+        // Wait for all expectations to be fulfilled within a timeout
+        wait(for: [expectation1, expectation2], timeout: 2.0)
+        
+        print(emittedPlaylistTitles)
+        
+        // Now perform your assertions
+        XCTAssertEqual(emittedPlaylistTitles.count, 3, "Should emit initial and updated playlist titles.")
+        
+        // Initial emission should be empty
+        XCTAssertEqual(emittedPlaylistTitles[0], [], "Initial playlist titles should be empty.")
+        
+        // After adding, the second emission should contain the new playlist
+        XCTAssertEqual(emittedPlaylistTitles[1], [newPlaylistName], "Playlist titles should include the new playlist.")
+        
+        XCTAssertEqual(emittedPlaylistTitles[2], [newPlaylistName, newPlaylistName], "Playlist titles should include the new playlist.")
+
+    }
+}
+
+
+private final class MockPlaylistRepository: PlaylistRepository {
+    
+    // CurrentValueSubject to hold the current state of playlists
+    private var playlistsSubject: CurrentValueSubject<[MolioPlaylist], Never>
+    
+    // Public publisher as required by the protocol
+    var playlistsPublisher: AnyPublisher<[MolioPlaylist], Never> {
+        playlistsSubject.eraseToAnyPublisher()
+    }
+    
+    // Internal storage for playlists
+    private var playlists: [MolioPlaylist]
+    
+    init(initialPlaylists: [MolioPlaylist] = []) {
+        self.playlists = initialPlaylists
+        self.playlistsSubject = CurrentValueSubject(initialPlaylists)
+    }
+    
+    // Adds a new playlist and publishes the updated list
+    func saveNewPlaylist(_ playlistName: String) async throws -> UUID {
+        let newPlaylist = MolioPlaylist(id: UUID(), name: playlistName, createdAt: .now, musicISRCs: [], filters: [])
+        playlists.append(newPlaylist)
+        playlistsSubject.send(playlists)
+        return newPlaylist.id
+    }
+    
+    // Deletes a playlist by name and publishes the updated list
+    func deletePlaylist(_ playlistName: String) {
+        playlists.removeAll { $0.name == playlistName }
+        playlistsSubject.send(playlists)
+    }
+    
+    // Fetches all playlists
+    func fetchPlaylists() -> [MolioPlaylist]? {
+        return playlists
+    }
+    
+    // Fetches a specific playlist by name
+    func fetchPlaylist(for name: String) async throws -> MolioPlaylist? {
+        return playlists.first { $0.name == name }
+    }
+    
+    // Adds music to a playlist
+    func addMusic(isrc: String, to playlistName: String) {
+    }
+    
+    // Deletes music from a playlist
+    func deleteMusic(isrc: String, in playlistName: String) {
+    }
+    
+    // Moves music within a playlist
+    func moveMusic(isrc: String, in playlistName: String, fromIndex: Int, toIndex: Int) {
+        
+    }
+}


### PR DESCRIPTION
# 수정 내용: PublishAllPlaylistTitleUseCase 구현하기

유저의 모든 플레이리스트들의 이름을 구독하는 유즈케이스입니다!

- 프로토콜 정의
- Default 구현체 정의
- 테스트 코드 작성
- DIContainer에 연결

# 스크린샷
<img width="515" alt="image" src="https://github.com/user-attachments/assets/8cb5db87-df35-47d3-ba3d-fc1d64ae7b23">

# 관련 이슈
#130 