### PR TITLE
feat: 플레이리스트 선택 기능 추가

### DIFF
--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -753,10 +753,10 @@
 			isa = PBXGroup;
 			children = (
 				F1E4059C2CEC935B00533701 /* Auth */,
-				2008FCBA2CE8A1B90060F3B8 /* MolioPlaylist.swift */,
-				881BBCBF2CDCF97900010A61 /* MusicFilter.swift */,
 				881622722CE3BAB900E81EA0 /* MusicDeck */,
 				881622732CE3BAC500E81EA0 /* MusicFilterProvider */,
+				2008FCBA2CE8A1B90060F3B8 /* MolioPlaylist.swift */,
+				881BBCBF2CDCF97900010A61 /* MusicFilter.swift */,
 				881BBCC02CDCF97900010A61 /* RecommendationRequestEntity.swift */,
 				F173693C2CDF191800F6242C /* MolioMusic.swift */,
 				88E4834D2CEDDD66003D624E /* MolioMusic+sample.swift */,

--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -20,7 +20,7 @@
 		2003BA162CDB8D69002CAB3E /* Font+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2003BA152CDB8D69002CAB3E /* Font+Extension.swift */; };
 		2003BA1C2CDB8EE5002CAB3E /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2003BA1B2CDB8EE5002CAB3E /* UILabel+Extension.swift */; };
 		2003BA222CDCB31B002CAB3E /* SwipeMusicViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2003BA212CDCB31B002CAB3E /* SwipeMusicViewModel.swift */; };
-		2008FCBB2CE8A1B90060F3B8 /* PlaylistEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2008FCBA2CE8A1B90060F3B8 /* PlaylistEntity.swift */; };
+		2008FCBB2CE8A1B90060F3B8 /* MolioPlaylist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2008FCBA2CE8A1B90060F3B8 /* MolioPlaylist.swift */; };
 		2009183C2CEC9C0E0058D8C7 /* CurrentPlaylistRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2009183B2CEC9C0E0058D8C7 /* CurrentPlaylistRepository.swift */; };
 		2009183E2CEC9C5B0058D8C7 /* DefaultCurrentPlaylistRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2009183D2CEC9C5B0058D8C7 /* DefaultCurrentPlaylistRepository.swift */; };
 		200918422CECA79A0058D8C7 /* UserDefaultsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200918412CECA79A0058D8C7 /* UserDefaultsError.swift */; };
@@ -45,6 +45,7 @@
 		2075FEC42CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC32CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift */; };
 		2075FEC62CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */; };
 		2075FEC82CECDF4D009834BE /* CoreDataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC72CECDF4D009834BE /* CoreDataError.swift */; };
+		20A500692CEF119000E13440 /* SelectPlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A500682CEF119000E13440 /* SelectPlaylistView.swift */; };
 		881622692CE3671400E81EA0 /* RandomMusicDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881622682CE3671400E81EA0 /* RandomMusicDeck.swift */; };
 		8816226B2CE3838B00E81EA0 /* DeckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8816226A2CE3838B00E81EA0 /* DeckTests.swift */; };
 		8816226D2CE3B11C00E81EA0 /* MusicDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8816226C2CE3B11C00E81EA0 /* MusicDeck.swift */; };
@@ -171,7 +172,7 @@
 		2003BA172CDB8DE0002CAB3E /* Text+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+Extension.swift"; sourceTree = "<group>"; };
 		2003BA1B2CDB8EE5002CAB3E /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
 		2003BA212CDCB31B002CAB3E /* SwipeMusicViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeMusicViewModel.swift; sourceTree = "<group>"; };
-		2008FCBA2CE8A1B90060F3B8 /* PlaylistEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistEntity.swift; sourceTree = "<group>"; };
+		2008FCBA2CE8A1B90060F3B8 /* MolioPlaylist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MolioPlaylist.swift; sourceTree = "<group>"; };
 		2009183B2CEC9C0E0058D8C7 /* CurrentPlaylistRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentPlaylistRepository.swift; sourceTree = "<group>"; };
 		2009183D2CEC9C5B0058D8C7 /* DefaultCurrentPlaylistRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCurrentPlaylistRepository.swift; sourceTree = "<group>"; };
 		200918412CECA79A0058D8C7 /* UserDefaultsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsError.swift; sourceTree = "<group>"; };
@@ -196,6 +197,7 @@
 		2075FEC32CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeCurrentPlaylistIUseCase.swift; sourceTree = "<group>"; };
 		2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChangeCurrentPlaylistIUseCase.swift; sourceTree = "<group>"; };
 		2075FEC72CECDF4D009834BE /* CoreDataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataError.swift; sourceTree = "<group>"; };
+		20A500682CEF119000E13440 /* SelectPlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectPlaylistView.swift; sourceTree = "<group>"; };
 		881622682CE3671400E81EA0 /* RandomMusicDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomMusicDeck.swift; sourceTree = "<group>"; };
 		8816226A2CE3838B00E81EA0 /* DeckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckTests.swift; sourceTree = "<group>"; };
 		8816226C2CE3B11C00E81EA0 /* MusicDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicDeck.swift; sourceTree = "<group>"; };
@@ -470,6 +472,14 @@
 			path = ChangeCurrentPlaylistIUseCase;
 			sourceTree = "<group>";
 		};
+		20A500672CEF117A00E13440 /* SelectPlaylist */ = {
+			isa = PBXGroup;
+			children = (
+				20A500682CEF119000E13440 /* SelectPlaylistView.swift */,
+			);
+			path = SelectPlaylist;
+			sourceTree = "<group>";
+		};
 		881622722CE3BAB900E81EA0 /* MusicDeck */ = {
 			isa = PBXGroup;
 			children = (
@@ -614,6 +624,7 @@
 			children = (
 				88E483442CEDDD3C003D624E /* PlaylistDetail */,
 				2075FEBF2CECDDA0009834BE /* CreatePlaylist */,
+				20A500672CEF117A00E13440 /* SelectPlaylist */,
 				B809707A2CDB4405007BC3C4 /* Common */,
 				F173691C2CDB991D00F6242C /* SwipeMusic */,
 				B88F80B72CE48906000480E6 /* MusicFilter */,
@@ -709,7 +720,7 @@
 			isa = PBXGroup;
 			children = (
 				F1E4059C2CEC935B00533701 /* Auth */,
-				2008FCBA2CE8A1B90060F3B8 /* PlaylistEntity.swift */,
+				2008FCBA2CE8A1B90060F3B8 /* MolioPlaylist.swift */,
 				881BBCBF2CDCF97900010A61 /* MusicFilter.swift */,
 				881622722CE3BAB900E81EA0 /* MusicDeck */,
 				881622732CE3BAC500E81EA0 /* MusicFilterProvider */,
@@ -1308,8 +1319,9 @@
 				2009183C2CEC9C0E0058D8C7 /* CurrentPlaylistRepository.swift in Sources */,
 				F17368FB2CD86B1100F6242C /* SceneDelegate.swift in Sources */,
 				2075FEC42CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift in Sources */,
-				2008FCBB2CE8A1B90060F3B8 /* PlaylistEntity.swift in Sources */,
+				2008FCBB2CE8A1B90060F3B8 /* MolioPlaylist.swift in Sources */,
 				F17369232CDC5E5F00F6242C /* MusicTagView.swift in Sources */,
+				20A500692CEF119000E13440 /* SelectPlaylistView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		2075FEC82CECDF4D009834BE /* CoreDataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC72CECDF4D009834BE /* CoreDataError.swift */; };
 		20A500692CEF119000E13440 /* SelectPlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A500682CEF119000E13440 /* SelectPlaylistView.swift */; };
 		20A5006B2CEF150F00E13440 /* SelectPlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A5006A2CEF150F00E13440 /* SelectPlaylistViewModel.swift */; };
+		20C655902CEF48C900C60B9C /* FetchAllPlaylistsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C6558F2CEF48C900C60B9C /* FetchAllPlaylistsUseCase.swift */; };
+		20C655922CEF48D100C60B9C /* DefaultFetchAllPlaylistsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C655912CEF48D100C60B9C /* DefaultFetchAllPlaylistsUseCase.swift */; };
 		881622692CE3671400E81EA0 /* RandomMusicDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881622682CE3671400E81EA0 /* RandomMusicDeck.swift */; };
 		8816226B2CE3838B00E81EA0 /* DeckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8816226A2CE3838B00E81EA0 /* DeckTests.swift */; };
 		8816226D2CE3B11C00E81EA0 /* MusicDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8816226C2CE3B11C00E81EA0 /* MusicDeck.swift */; };
@@ -203,6 +205,8 @@
 		2075FEC72CECDF4D009834BE /* CoreDataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataError.swift; sourceTree = "<group>"; };
 		20A500682CEF119000E13440 /* SelectPlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectPlaylistView.swift; sourceTree = "<group>"; };
 		20A5006A2CEF150F00E13440 /* SelectPlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectPlaylistViewModel.swift; sourceTree = "<group>"; };
+		20C6558F2CEF48C900C60B9C /* FetchAllPlaylistsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAllPlaylistsUseCase.swift; sourceTree = "<group>"; };
+		20C655912CEF48D100C60B9C /* DefaultFetchAllPlaylistsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFetchAllPlaylistsUseCase.swift; sourceTree = "<group>"; };
 		881622682CE3671400E81EA0 /* RandomMusicDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomMusicDeck.swift; sourceTree = "<group>"; };
 		8816226A2CE3838B00E81EA0 /* DeckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckTests.swift; sourceTree = "<group>"; };
 		8816226C2CE3B11C00E81EA0 /* MusicDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicDeck.swift; sourceTree = "<group>"; };
@@ -489,6 +493,15 @@
 			path = SelectPlaylist;
 			sourceTree = "<group>";
 		};
+		20C6558E2CEF48BA00C60B9C /* FetchAllPlaylistsUseCase */ = {
+			isa = PBXGroup;
+			children = (
+				20C6558F2CEF48C900C60B9C /* FetchAllPlaylistsUseCase.swift */,
+				20C655912CEF48D100C60B9C /* DefaultFetchAllPlaylistsUseCase.swift */,
+			);
+			path = FetchAllPlaylistsUseCase;
+			sourceTree = "<group>";
+		};
 		881622722CE3BAB900E81EA0 /* MusicDeck */ = {
 			isa = PBXGroup;
 			children = (
@@ -711,6 +724,7 @@
 		B80970812CDB4472007BC3C4 /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
+				20C6558E2CEF48BA00C60B9C /* FetchAllPlaylistsUseCase */,
 				88C8B5E92CEF1DF60079ACB5 /* PublishAllMusicInCurrentPlaylistUseCase */,
 				2075FEC22CECDE0F009834BE /* ChangeCurrentPlaylistIUseCase */,
 				F1E4059F2CEC9E4100533701 /* SignInAppleUseCase */,
@@ -1236,6 +1250,7 @@
 				B8D554842CE0F3F3007CCD6D /* SpotifyAccessTokenResponseDTO.swift in Sources */,
 				F173697B2CE4AAC600F6242C /* AudioPlayer.swift in Sources */,
 				F1E4058C2CEB8FC500533701 /* LoginViewController.swift in Sources */,
+				20C655922CEF48D100C60B9C /* DefaultFetchAllPlaylistsUseCase.swift in Sources */,
 				B8D553F22CDFE33A007CCD6D /* SpotifyAuthorizationAPI.swift in Sources */,
 				2010484D2CE9FF570015E800 /* CreatePlaylistView.swift in Sources */,
 				88E483492CEDDD4A003D624E /* PlaylistDetailView.swift in Sources */,
@@ -1344,6 +1359,7 @@
 				2075FEC42CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift in Sources */,
 				2008FCBB2CE8A1B90060F3B8 /* MolioPlaylist.swift in Sources */,
 				F17369232CDC5E5F00F6242C /* MusicTagView.swift in Sources */,
+				20C655902CEF48C900C60B9C /* FetchAllPlaylistsUseCase.swift in Sources */,
 				20A500692CEF119000E13440 /* SelectPlaylistView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		2075FEC62CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */; };
 		2075FEC82CECDF4D009834BE /* CoreDataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC72CECDF4D009834BE /* CoreDataError.swift */; };
 		20A500692CEF119000E13440 /* SelectPlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A500682CEF119000E13440 /* SelectPlaylistView.swift */; };
+		20A5006B2CEF150F00E13440 /* SelectPlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A5006A2CEF150F00E13440 /* SelectPlaylistViewModel.swift */; };
 		881622692CE3671400E81EA0 /* RandomMusicDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881622682CE3671400E81EA0 /* RandomMusicDeck.swift */; };
 		8816226B2CE3838B00E81EA0 /* DeckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8816226A2CE3838B00E81EA0 /* DeckTests.swift */; };
 		8816226D2CE3B11C00E81EA0 /* MusicDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8816226C2CE3B11C00E81EA0 /* MusicDeck.swift */; };
@@ -198,6 +199,7 @@
 		2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChangeCurrentPlaylistIUseCase.swift; sourceTree = "<group>"; };
 		2075FEC72CECDF4D009834BE /* CoreDataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataError.swift; sourceTree = "<group>"; };
 		20A500682CEF119000E13440 /* SelectPlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectPlaylistView.swift; sourceTree = "<group>"; };
+		20A5006A2CEF150F00E13440 /* SelectPlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectPlaylistViewModel.swift; sourceTree = "<group>"; };
 		881622682CE3671400E81EA0 /* RandomMusicDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomMusicDeck.swift; sourceTree = "<group>"; };
 		8816226A2CE3838B00E81EA0 /* DeckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckTests.swift; sourceTree = "<group>"; };
 		8816226C2CE3B11C00E81EA0 /* MusicDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicDeck.swift; sourceTree = "<group>"; };
@@ -476,6 +478,7 @@
 			isa = PBXGroup;
 			children = (
 				20A500682CEF119000E13440 /* SelectPlaylistView.swift */,
+				20A5006A2CEF150F00E13440 /* SelectPlaylistViewModel.swift */,
 			);
 			path = SelectPlaylist;
 			sourceTree = "<group>";
@@ -1297,6 +1300,7 @@
 				B8046A492CEA1AF500933704 /* MusicFilterViewModel.swift in Sources */,
 				F17369462CDF24A100F6242C /* FetchRecommendedMusicUseCase.swift in Sources */,
 				F17369612CE36D8000F6242C /* FetchImageUseCase.swift in Sources */,
+				20A5006B2CEF150F00E13440 /* SelectPlaylistViewModel.swift in Sources */,
 				88F9B5FC2CEDDDAE002C1114 /* PlaylistDetailViewModel.swift in Sources */,
 				F17369772CE389AA00F6242C /* SwipeMusicTrackModel.swift in Sources */,
 				B8D553F02CDFE2F5007CCD6D /* HTTPMethod.swift in Sources */,

--- a/Molio/Source/Data/Repository/DefaultPlaylistRepository.swift
+++ b/Molio/Source/Data/Repository/DefaultPlaylistRepository.swift
@@ -114,7 +114,6 @@ final class DefaultPlaylistRepository: PlaylistRepository {
                         continuation.resume(returning: nil)
                         return
                     }
-                    print("fetchPlaylist", playlist)
                     
                     let molioPlaylist = MolioPlaylist(
                         id: playlist.id,

--- a/Molio/Source/Domain/Entity/MolioPlaylist.swift
+++ b/Molio/Source/Domain/Entity/MolioPlaylist.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct MolioPlaylist {
+struct MolioPlaylist: Identifiable {
     let id: UUID
     let name: String
     let createdAt: Date

--- a/Molio/Source/Domain/RepositoryInterface/PlaylistRepository.swift
+++ b/Molio/Source/Domain/RepositoryInterface/PlaylistRepository.swift
@@ -11,5 +11,5 @@ protocol PlaylistRepository {
     func saveNewPlaylist(_ playlistName: String) async throws -> UUID
     func deletePlaylist(_ playlistName: String)
     func fetchPlaylists() -> [MolioPlaylist]?
-    func fetchPlaylist(for name: String)  async throws -> MolioPlaylist?
+    func fetchPlaylist(for id: String) async throws -> MolioPlaylist?
 }

--- a/Molio/Source/Domain/UseCase/FetchAllPlaylistsUseCase/DefaultFetchAllPlaylistsUseCase.swift
+++ b/Molio/Source/Domain/UseCase/FetchAllPlaylistsUseCase/DefaultFetchAllPlaylistsUseCase.swift
@@ -1,0 +1,13 @@
+final class DefaultFetchAllPlaylistsUseCase: FetchAllPlaylistsUseCase {
+    private let playlistRepository: any PlaylistRepository
+
+    init(
+        playlistRepository: any PlaylistRepository = DIContainer.shared.resolve()
+    ) {
+        self.playlistRepository = playlistRepository
+    }
+    
+    func execute() -> [MolioPlaylist] {
+        playlistRepository.fetchPlaylists() ?? []
+    }
+}

--- a/Molio/Source/Domain/UseCase/FetchAllPlaylistsUseCase/DefaultFetchAllPlaylistsUseCase.swift
+++ b/Molio/Source/Domain/UseCase/FetchAllPlaylistsUseCase/DefaultFetchAllPlaylistsUseCase.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 final class DefaultFetchAllPlaylistsUseCase: FetchAllPlaylistsUseCase {
     private let playlistRepository: any PlaylistRepository
 
@@ -7,7 +9,12 @@ final class DefaultFetchAllPlaylistsUseCase: FetchAllPlaylistsUseCase {
         self.playlistRepository = playlistRepository
     }
     
-    func execute() -> [MolioPlaylist] {
-        playlistRepository.fetchPlaylists() ?? []
+    func execute() async -> [MolioPlaylist] {
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                let playlists = self.playlistRepository.fetchPlaylists() ?? []
+                continuation.resume(returning: playlists)
+            }
+        }
     }
 }

--- a/Molio/Source/Domain/UseCase/FetchAllPlaylistsUseCase/FetchAllPlaylistsUseCase.swift
+++ b/Molio/Source/Domain/UseCase/FetchAllPlaylistsUseCase/FetchAllPlaylistsUseCase.swift
@@ -1,3 +1,3 @@
 protocol FetchAllPlaylistsUseCase {
-    func execute() -> [MolioPlaylist]
+    func execute() async -> [MolioPlaylist] 
 }

--- a/Molio/Source/Domain/UseCase/FetchAllPlaylistsUseCase/FetchAllPlaylistsUseCase.swift
+++ b/Molio/Source/Domain/UseCase/FetchAllPlaylistsUseCase/FetchAllPlaylistsUseCase.swift
@@ -1,0 +1,3 @@
+protocol FetchAllPlaylistsUseCase {
+    func execute() -> [MolioPlaylist]
+}

--- a/Molio/Source/Domain/UseCase/PublishCurrentPlaylistUseCase/DefaultPublishCurrentPlaylistUseCase.swift
+++ b/Molio/Source/Domain/UseCase/PublishCurrentPlaylistUseCase/DefaultPublishCurrentPlaylistUseCase.swift
@@ -24,9 +24,8 @@ final class DefaultPublishCurrentPlaylistUseCase: PublishCurrentPlaylistUseCase 
                             promise(.success(nil))
                             return                         
                             }                    
+                        let playlist = try await self.playlistRepository.fetchPlaylist(for: playlistUUID.uuidString)
 
-                        let playlist = try? await self.playlistRepository.fetchPlaylist(for: playlistUUID.uuidString)
-                        
                         promise(.success(playlist))
                     }
                     

--- a/Molio/Source/Presentation/CreatePlaylist/CreatePlaylistView.swift
+++ b/Molio/Source/Presentation/CreatePlaylist/CreatePlaylistView.swift
@@ -10,7 +10,7 @@ struct CreatePlaylistView: View {
 
     var body: some View {
         ZStack {
-            Color(.clear)
+            Color.background
             VStack(spacing: 20) {
                 Spacer()
                     .frame(height: 40)
@@ -62,10 +62,41 @@ struct CreatePlaylistView: View {
                 Spacer()
             }
         }.ignoresSafeArea()
+        
     }
+
 }
 
 #Preview {
     CreatePlaylistView(viewModel: CreatePlaylistViewModel())
         .background(Color.background)
+}
+
+struct GlassmorphismBackground: View {
+    var gradientColors: [Color] = [
+        Color.white.opacity(0.23),
+        Color.white.opacity(0.30),
+        Color.white.opacity(0.25)
+    ]
+    var gradientStartPoint: UnitPoint = .topLeading
+    var gradientEndPoint: UnitPoint = .bottomTrailing
+    var blurRadius: CGFloat = 10.0
+
+    var body: some View {
+        ZStack {
+            // 그라데이션 레이어
+            LinearGradient(
+                gradient: Gradient(colors: gradientColors),
+                startPoint: gradientStartPoint,
+                endPoint: gradientEndPoint
+            )
+            .ignoresSafeArea()
+            
+            // 블러 효과
+            Color.black
+                .opacity(0.2) // 반투명 색상
+                .blur(radius: blurRadius)
+                .ignoresSafeArea()
+        }
+    }
 }

--- a/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistView.swift
+++ b/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct SelectPlaylistView: View {
+    @Environment(\.dismiss) var dismiss
+    @FocusState private var isFocused: Bool
+    var playlists: [MolioPlaylist] = [MolioPlaylist(id: UUID(), name: "플레이리스트 1", createdAt: Date(), musicISRCs: [], filters: []), MolioPlaylist(id: UUID(), name: "플레이리스트 2", createdAt: Date(), musicISRCs: [], filters: [])]
+    
+    //@ObservedObject var viewModel: CreatePlaylistViewModel
+    
+    var placeholder: String = "00님의 몰리오"
+    
+    var body: some View {
+        ZStack {
+            Color(.clear)
+            VStack(alignment: .leading, spacing: 20) {
+                Spacer()
+                    .frame(height: 40)
+                
+                Text("그냥님의 몰리오")
+                    .font(.custom(PretendardFontName.Bold, size: 28))
+                    .foregroundStyle(Color.white)
+                
+                List(playlists) { playlist in
+                    Button(action: {
+                    }) {
+                        HStack {
+                            Text(playlist.name)
+                            Spacer()
+                            Image(systemName: "checkmark")
+                                .foregroundColor(.blue)
+                        }
+                    }
+                    .listRowBackground(Color.clear)
+                }
+                .background(Color.clear)
+                Spacer()
+            }
+            .padding(.horizontal, 22)
+            
+        }.ignoresSafeArea()
+    }
+}
+
+#Preview {
+    SelectPlaylistView()
+        .background(Color.background)
+}

--- a/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistView.swift
+++ b/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistView.swift
@@ -67,6 +67,11 @@ struct SelectPlaylistView: View {
                             .presentationDetents([.fraction(0.5)])
                             .presentationDragIndicator(.visible)
                     }
+                    .onChange(of: isModalPresented) { newValue in
+                        if !newValue {
+                            viewModel.reloadData()
+                        }
+                    }
                     
                     Spacer()
                 })

--- a/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistView.swift
+++ b/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistView.swift
@@ -4,9 +4,7 @@ struct SelectPlaylistView: View {
     @Environment(\.dismiss) var dismiss
     @StateObject var viewModel: SelectPlaylistViewModel
     @State private var isModalPresented = false
-    
-    var placeholder: String = "00님의 몰리오"
-    
+        
     var body: some View {
         ZStack {
             Color(.clear)
@@ -14,7 +12,7 @@ struct SelectPlaylistView: View {
                 Spacer()
                     .frame(height: 40)
                 
-                Text("그냥님의 몰리오")
+                Text("그냥님의 몰리오") // TODO: 로그인 정보 불어와 적용하기
                     .font(.custom(PretendardFontName.Bold, size: 36))
                     .foregroundStyle(Color.white)
                     .padding(.horizontal, 22)
@@ -69,7 +67,7 @@ struct SelectPlaylistView: View {
                     }
                     .onChange(of: isModalPresented) { newValue in
                         if !newValue {
-                            viewModel.reloadData()
+                            viewModel.fetchPlaylists()
                         }
                     }
                     

--- a/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistView.swift
+++ b/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistView.swift
@@ -2,46 +2,76 @@ import SwiftUI
 
 struct SelectPlaylistView: View {
     @Environment(\.dismiss) var dismiss
-    @FocusState private var isFocused: Bool
-    var playlists: [MolioPlaylist] = [MolioPlaylist(id: UUID(), name: "플레이리스트 1", createdAt: Date(), musicISRCs: [], filters: []), MolioPlaylist(id: UUID(), name: "플레이리스트 2", createdAt: Date(), musicISRCs: [], filters: [])]
-    
-    //@ObservedObject var viewModel: CreatePlaylistViewModel
+    @ObservedObject var viewModel: SelectPlaylistViewModel
     
     var placeholder: String = "00님의 몰리오"
     
     var body: some View {
         ZStack {
             Color(.clear)
-            VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 0) {
                 Spacer()
                     .frame(height: 40)
                 
                 Text("그냥님의 몰리오")
-                    .font(.custom(PretendardFontName.Bold, size: 28))
+                    .font(.custom(PretendardFontName.Bold, size: 36))
                     .foregroundStyle(Color.white)
+                    .padding(.horizontal, 22)
                 
-                List(playlists) { playlist in
+                Spacer()
+                    .frame(height: 5)
+                
+                List(viewModel.playlists) { playlist in
                     Button(action: {
+                        viewModel.selectedPlaylist = playlist
                     }) {
                         HStack {
                             Text(playlist.name)
+                                .font(.custom(PretendardFontName.Medium, size: 18))
+                                .tint(.white)
+                                .opacity(0.8)
+                                .frame(height: 50)
+
                             Spacer()
-                            Image(systemName: "checkmark")
-                                .foregroundColor(.blue)
+                            if viewModel.selectedPlaylist?.id == playlist.id {
+                                Image(systemName: "checkmark")
+                                    .foregroundStyle(.main)
+                            }
                         }
                     }
                     .listRowBackground(Color.clear)
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+
                 }
-                .background(Color.clear)
+                .frame(minHeight: 200)
+                .padding(.horizontal, 0)
+                .padding(.vertical, 0)
+                .scrollContentBackground(.hidden)
+
+                HStack (alignment: .center, content: {
+                    Spacer()
+                    
+                    Button(action: {
+                    }) {
+                        Image.molioBlack(systemName: "plus", size: 20, color: .white)
+                            .frame(width: 40, height: 40)
+                            .background(Color.white.opacity(0.3))
+                            .clipShape(Circle())
+                            .shadow(radius: 5)
+                    }
+                    
+                    Spacer()
+                })
+                .padding(.top, 20)
+        
                 Spacer()
             }
-            .padding(.horizontal, 22)
-            
-        }.ignoresSafeArea()
+        }
     }
 }
 
 #Preview {
-    SelectPlaylistView()
+    SelectPlaylistView(viewModel: SelectPlaylistViewModel())
         .background(Color.background)
 }

--- a/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistView.swift
+++ b/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistView.swift
@@ -3,7 +3,8 @@ import SwiftUI
 struct SelectPlaylistView: View {
     @Environment(\.dismiss) var dismiss
     @ObservedObject var viewModel: SelectPlaylistViewModel
-    
+    @State private var isModalPresented = false 
+
     var placeholder: String = "00님의 몰리오"
     
     var body: some View {
@@ -53,12 +54,18 @@ struct SelectPlaylistView: View {
                     Spacer()
                     
                     Button(action: {
+                        isModalPresented.toggle()
                     }) {
                         Image.molioBlack(systemName: "plus", size: 20, color: .white)
                             .frame(width: 40, height: 40)
                             .background(Color.white.opacity(0.3))
                             .clipShape(Circle())
                             .shadow(radius: 5)
+                    }
+                    .sheet(isPresented: $isModalPresented) {
+                        CreatePlaylistView(viewModel: CreatePlaylistViewModel(createPlaylistUseCase: DefaultCreatePlaylistUseCase(repository: DefaultPlaylistRepository()), changeCurrentPlaylistUseCase: DefaultChangeCurrentPlaylistUseCase(repository: DefaultCurrentPlaylistRepository())))
+                            .presentationDetents([.fraction(0.5)]) 
+                            .presentationDragIndicator(.visible)
                     }
                     
                     Spacer()

--- a/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistView.swift
+++ b/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistView.swift
@@ -2,9 +2,9 @@ import SwiftUI
 
 struct SelectPlaylistView: View {
     @Environment(\.dismiss) var dismiss
-    @ObservedObject var viewModel: SelectPlaylistViewModel
-    @State private var isModalPresented = false 
-
+    @StateObject var viewModel: SelectPlaylistViewModel
+    @State private var isModalPresented = false
+    
     var placeholder: String = "00님의 몰리오"
     
     var body: some View {
@@ -22,9 +22,9 @@ struct SelectPlaylistView: View {
                 Spacer()
                     .frame(height: 5)
                 
-                List(viewModel.playlists) { playlist in
+                List(viewModel.playlists, id: \.id) { playlist in
                     Button(action: {
-                        viewModel.selectedPlaylist = playlist
+                        viewModel.selectPlaylist(playlist)
                     }) {
                         HStack {
                             Text(playlist.name)
@@ -32,7 +32,7 @@ struct SelectPlaylistView: View {
                                 .tint(.white)
                                 .opacity(0.8)
                                 .frame(height: 50)
-
+                            
                             Spacer()
                             if viewModel.selectedPlaylist?.id == playlist.id {
                                 Image(systemName: "checkmark")
@@ -43,14 +43,14 @@ struct SelectPlaylistView: View {
                     .listRowBackground(Color.clear)
                     .listRowInsets(EdgeInsets())
                     .listRowSeparator(.hidden)
-
+                    
                 }
                 .frame(minHeight: 200)
                 .padding(.horizontal, 0)
                 .padding(.vertical, 0)
                 .scrollContentBackground(.hidden)
-
-                HStack (alignment: .center, content: {
+               
+                HStack(alignment: .center, content: {
                     Spacer()
                     
                     Button(action: {
@@ -64,16 +64,18 @@ struct SelectPlaylistView: View {
                     }
                     .sheet(isPresented: $isModalPresented) {
                         CreatePlaylistView(viewModel: CreatePlaylistViewModel(createPlaylistUseCase: DefaultCreatePlaylistUseCase(repository: DefaultPlaylistRepository()), changeCurrentPlaylistUseCase: DefaultChangeCurrentPlaylistUseCase(repository: DefaultCurrentPlaylistRepository())))
-                            .presentationDetents([.fraction(0.5)]) 
+                            .presentationDetents([.fraction(0.5)])
                             .presentationDragIndicator(.visible)
                     }
                     
                     Spacer()
                 })
                 .padding(.top, 20)
-        
+                
                 Spacer()
             }
+        }.onDisappear {
+            viewModel.savePlaylist()
         }
     }
 }

--- a/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistViewModel.swift
+++ b/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistViewModel.swift
@@ -19,14 +19,17 @@ final class SelectPlaylistViewModel: ObservableObject {
         self.changeCurrentPlaylistUseCase = changeCurrentPlaylistUseCase
         self.publishCurrentPlaylistUseCase = publishCurrentPlaylistUseCase
         
-        reloadData()
-    }
-
-    func reloadData() {
         bindPublishCurrentPlaylist()
         fetchPlaylists()
     }
-
+    
+    func fetchPlaylists() {
+        Task {
+            @MainActor in
+            self.playlists = await fetchAllPlaylistsUseCase.execute()
+        }
+    }
+    
     func selectPlaylist(_ playlist: MolioPlaylist) {
         selectedPlaylist = playlist
     }
@@ -35,17 +38,8 @@ final class SelectPlaylistViewModel: ObservableObject {
         guard let selectedPlaylist else { return }
         changeCurrentPlaylistUseCase.execute(playlistId: selectedPlaylist.id)
     }
-
-    // MARK: - Private Method
     
-    private func fetchPlaylists() {
-        Task {
-            let playlists = await fetchAllPlaylistsUseCase.execute()
-            DispatchQueue.main.async {
-                self.playlists = playlists
-            }
-        }
-    }
+    // MARK: - Private Method
     
     private func bindPublishCurrentPlaylist() {
         publishCurrentPlaylistUseCase.execute()

--- a/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistViewModel.swift
+++ b/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistViewModel.swift
@@ -1,8 +1,39 @@
-//
-//  SelectPlaylistViewModel.swift
-//  Molio
-//
-//  Created by p_kxn_g on 11/21/24.
-//
-
 import Foundation
+
+final class SelectPlaylistViewModel: ObservableObject {
+//    private let createPlaylistUseCase: CreatePlaylistUseCase
+//    private let changeCurrentPlaylistUseCase: ChangeCurrentPlaylistUseCase
+    @Published var playlists: [MolioPlaylist] = [
+        MolioPlaylist(id: UUID(), name: "🎧 카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
+
+    ]
+        
+
+    
+    @Published var selectedPlaylist: MolioPlaylist?
+    
+//    init(
+//        createPlaylistUseCase: CreatePlaylistUseCase = DIContainer.shared.resolve(),
+//        changeCurrentPlaylistUseCase: ChangeCurrentPlaylistUseCase = DIContainer.shared.resolve()
+//    ) {
+//        self.createPlaylistUseCase = createPlaylistUseCase
+//        self.changeCurrentPlaylistUseCase = changeCurrentPlaylistUseCase
+//    }
+    
+  
+}

--- a/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistViewModel.swift
+++ b/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistViewModel.swift
@@ -19,19 +19,14 @@ final class SelectPlaylistViewModel: ObservableObject {
         self.changeCurrentPlaylistUseCase = changeCurrentPlaylistUseCase
         self.publishCurrentPlaylistUseCase = publishCurrentPlaylistUseCase
         
+        reloadData()
+    }
+
+    func reloadData() {
         bindPublishCurrentPlaylist()
         fetchPlaylists()
     }
-    
-    func fetchPlaylists() {
-        Task {
-            let playlists = await fetchAllPlaylistsUseCase.execute()
-            DispatchQueue.main.async {
-                self.playlists = playlists
-            }
-        }
-    }
-    
+
     func selectPlaylist(_ playlist: MolioPlaylist) {
         selectedPlaylist = playlist
     }
@@ -39,6 +34,17 @@ final class SelectPlaylistViewModel: ObservableObject {
     func savePlaylist () {
         guard let selectedPlaylist else { return }
         changeCurrentPlaylistUseCase.execute(playlistId: selectedPlaylist.id)
+    }
+
+    // MARK: - Private Method
+    
+    private func fetchPlaylists() {
+        Task {
+            let playlists = await fetchAllPlaylistsUseCase.execute()
+            DispatchQueue.main.async {
+                self.playlists = playlists
+            }
+        }
     }
     
     private func bindPublishCurrentPlaylist() {

--- a/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistViewModel.swift
+++ b/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistViewModel.swift
@@ -1,39 +1,53 @@
+import Combine
 import Foundation
 
 final class SelectPlaylistViewModel: ObservableObject {
-//    private let createPlaylistUseCase: CreatePlaylistUseCase
-//    private let changeCurrentPlaylistUseCase: ChangeCurrentPlaylistUseCase
-    @Published var playlists: [MolioPlaylist] = [
-        MolioPlaylist(id: UUID(), name: "🎧 카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-        MolioPlaylist(id: UUID(), name: "🤸🏼‍♂️ 헬스할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filters: []),
-
-    ]
-        
-
-    
+    @Published var playlists: [MolioPlaylist] = []
     @Published var selectedPlaylist: MolioPlaylist?
     
-//    init(
-//        createPlaylistUseCase: CreatePlaylistUseCase = DIContainer.shared.resolve(),
-//        changeCurrentPlaylistUseCase: ChangeCurrentPlaylistUseCase = DIContainer.shared.resolve()
-//    ) {
-//        self.createPlaylistUseCase = createPlaylistUseCase
-//        self.changeCurrentPlaylistUseCase = changeCurrentPlaylistUseCase
-//    }
+    private let fetchAllPlaylistsUseCase: FetchAllPlaylistsUseCase
+    private let changeCurrentPlaylistUseCase: ChangeCurrentPlaylistUseCase
+    private let publishCurrentPlaylistUseCase: PublishCurrentPlaylistUseCase
+    private var cancellables = Set<AnyCancellable>()
     
-  
+    init(
+        fetchAllPlaylistsUseCase: FetchAllPlaylistsUseCase = DefaultFetchAllPlaylistsUseCase(),
+        changeCurrentPlaylistUseCase: ChangeCurrentPlaylistUseCase = DefaultChangeCurrentPlaylistUseCase(),
+        publishCurrentPlaylistUseCase: PublishCurrentPlaylistUseCase = DIContainer.shared.resolve()
+    ) {
+        self.fetchAllPlaylistsUseCase = fetchAllPlaylistsUseCase
+        self.changeCurrentPlaylistUseCase = changeCurrentPlaylistUseCase
+        self.publishCurrentPlaylistUseCase = publishCurrentPlaylistUseCase
+        
+        bindPublishCurrentPlaylist()
+        fetchPlaylists()
+    }
+    
+    func fetchPlaylists() {
+        Task {
+            let playlists = await fetchAllPlaylistsUseCase.execute()
+            DispatchQueue.main.async {
+                self.playlists = playlists
+            }
+        }
+    }
+    
+    func selectPlaylist(_ playlist: MolioPlaylist) {
+        selectedPlaylist = playlist
+    }
+    
+    func savePlaylist () {
+        guard let selectedPlaylist else { return }
+        changeCurrentPlaylistUseCase.execute(playlistId: selectedPlaylist.id)
+    }
+    
+    private func bindPublishCurrentPlaylist() {
+        publishCurrentPlaylistUseCase.execute()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] publishedPlaylist in
+                guard let self = self else { return }
+                self.selectedPlaylist = publishedPlaylist
+            }
+            .store(in: &cancellables)
+    }
 }

--- a/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistViewModel.swift
+++ b/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  SelectPlaylistViewModel.swift
+//  Molio
+//
+//  Created by p_kxn_g on 11/21/24.
+//
+
+import Foundation

--- a/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
+++ b/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
@@ -272,9 +272,7 @@ final class SwipeMusicViewController: UIViewController {
     }
     
     @objc func didTapPlaylistSelectButton() {
-        // TODO: DI Container로 의존성 주입
-        let playlistView = CreatePlaylistView(viewModel: CreatePlaylistViewModel(createPlaylistUseCase: DefaultCreatePlaylistUseCase(repository: DefaultPlaylistRepository()), changeCurrentPlaylistUseCase: DefaultChangeCurrentPlaylistUseCase(repository: DefaultCurrentPlaylistRepository())))
-        
+        // TODO: DI Container로 의존성 주입        
         let selectplaylistView = SelectPlaylistView(viewModel: SelectPlaylistViewModel())
         self.presentCustomSheet(
             content: selectplaylistView
@@ -292,6 +290,7 @@ final class SwipeMusicViewController: UIViewController {
         )
         let playlistDetailView = PlaylistDetailView(viewModel: viewModel)
         let hostingController = UIHostingController(rootView: playlistDetailView)
+        hostingController.view.backgroundColor = .clear
         self.navigationController?.pushViewController(hostingController, animated: true)
     }
     

--- a/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
+++ b/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
@@ -6,7 +6,7 @@ final class SwipeMusicViewController: UIViewController {
     private var input: SwipeMusicViewModel.Input
     private var output: SwipeMusicViewModel.Output
     private let musicPlayer: AudioPlayer = SwipeMusicPlayer()
-
+    
     private let musicCardDidChangeSwipePublisher = PassthroughSubject<CGFloat, Never>()
     private let musicCardDidFinishSwipePublisher = PassthroughSubject<CGFloat, Never>()
     private let likeButtonDidTapPublisher = PassthroughSubject<Void, Never>()
@@ -18,7 +18,7 @@ final class SwipeMusicViewController: UIViewController {
     private let basicBackgroundColor = UIColor(resource: .background)
     private var impactFeedBack = UIImpactFeedbackGenerator(style: .medium)
     private var hasProvidedImpactFeedback: Bool = false
-
+    
     private let playlistSelectButton: UIButton = {
         let button = UIButton()
         button.layer.cornerRadius = 10
@@ -30,7 +30,7 @@ final class SwipeMusicViewController: UIViewController {
     
     private let selectedPlaylistTitleLabel: UILabel = {
         let label = UILabel()
-        label.molioMedium(text: "🎧카공할 때 듣는 플리", size: 16) // TODO: 서버 연결시 text 제거
+        label.molioMedium( text: "", size: 16)
         label.textColor = .white
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -112,7 +112,7 @@ final class SwipeMusicViewController: UIViewController {
             dislikeButtonDidTap: dislikeButtonDidTapPublisher.eraseToAnyPublisher()
         )
         self.output = viewModel.transform(from: input)
-
+        
         super.init(coder: coder)
     }
     
@@ -130,6 +130,14 @@ final class SwipeMusicViewController: UIViewController {
     }
     
     private func setupBindings() {
+        output.selectedPlaylist
+            .receive(on: RunLoop.main)
+            .sink { [weak self] playlist in
+                guard let self else { return }
+                self.selectedPlaylistTitleLabel.text = playlist.name
+            }
+            .store(in: &cancellables)
+        
         output.currentMusicTrack
             .receive(on: RunLoop.main)
             .sink { [weak self] music in
@@ -162,7 +170,7 @@ final class SwipeMusicViewController: UIViewController {
                 self.dislikeButton.isHighlighted = buttonHighlight.isDislikeHighlighted
             }
             .store(in: &cancellables)
-
+        
         output.musicCardSwipeAnimation
             .receive(on: RunLoop.main)
             .sink { [weak self] swipeDirection in
@@ -181,7 +189,7 @@ final class SwipeMusicViewController: UIViewController {
     private func animateMusicCard(direction: SwipeMusicViewModel.SwipeDirection) {
         let currentCenter = currentCardView.center
         let frameWidth = view.frame.width
-
+        
         switch direction {
         case .left, .right:
             self.isMusicCardAnimating = true
@@ -204,7 +212,7 @@ final class SwipeMusicViewController: UIViewController {
                     }
                     
                     self.isMusicCardAnimating = false
-            })
+                })
         case .none:
             UIView.animate(withDuration: 0.3) { [weak self] in
                 guard let self else { return }
@@ -238,7 +246,7 @@ final class SwipeMusicViewController: UIViewController {
         filterButton.addTarget(self, action: #selector(didTapFilterButton), for: .touchUpInside)
         myMolioButton.addTarget(self, action: #selector(didTapMyMolioButton), for: .touchUpInside)
     }
-
+    
     /// 사용자에게 진동 feedback을 주는 메서드
     private func providedImpactFeedback(translationX: CGFloat) {
         if abs(translationX) > viewModel.swipeThreshold && !hasProvidedImpactFeedback {
@@ -248,7 +256,7 @@ final class SwipeMusicViewController: UIViewController {
             hasProvidedImpactFeedback = false
         }
     }
-
+    
     @objc private func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
         guard let card = gesture.view else { return }
         
@@ -266,13 +274,13 @@ final class SwipeMusicViewController: UIViewController {
     @objc private func didTapLikeButton() {
         likeButtonDidTapPublisher.send()
     }
-
+    
     @objc private func didTapDislikeButton() {
         dislikeButtonDidTapPublisher.send()
     }
     
     @objc func didTapPlaylistSelectButton() {
-        // TODO: DI Container로 의존성 주입        
+        // TODO: DI Container로 의존성 주입
         let selectplaylistView = SelectPlaylistView(viewModel: SelectPlaylistViewModel())
         self.presentCustomSheet(
             content: selectplaylistView

--- a/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
+++ b/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
@@ -274,8 +274,10 @@ final class SwipeMusicViewController: UIViewController {
     @objc func didTapPlaylistSelectButton() {
         // TODO: DI Container로 의존성 주입
         let playlistView = CreatePlaylistView(viewModel: CreatePlaylistViewModel(createPlaylistUseCase: DefaultCreatePlaylistUseCase(repository: DefaultPlaylistRepository()), changeCurrentPlaylistUseCase: DefaultChangeCurrentPlaylistUseCase(repository: DefaultCurrentPlaylistRepository())))
+        
+        let selectplaylistView = SelectPlaylistView(viewModel: SelectPlaylistViewModel())
         self.presentCustomSheet(
-            content: playlistView
+            content: selectplaylistView
         )
     }
     

--- a/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
+++ b/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
@@ -280,7 +280,6 @@ final class SwipeMusicViewController: UIViewController {
     }
     
     @objc func didTapPlaylistSelectButton() {
-        // TODO: DI Container로 의존성 주입
         let selectplaylistView = SelectPlaylistView(viewModel: SelectPlaylistViewModel())
         self.presentCustomSheet(
             content: selectplaylistView
@@ -288,7 +287,6 @@ final class SwipeMusicViewController: UIViewController {
     }
     
     @objc private func didTapMyMolioButton() {
-        // TODO: DI Container로 의존성 주입
         let viewModel = PlaylistDetailViewModel(
             publishCurrentPlaylistUseCase: DefaultPublishCurrentPlaylistUseCase(
                 playlistRepository: DefaultPlaylistRepository(),

--- a/Molio/Source/Presentation/SwipeMusic/ViewModel/SwipeMusicViewModel.swift
+++ b/Molio/Source/Presentation/SwipeMusic/ViewModel/SwipeMusicViewModel.swift
@@ -38,6 +38,7 @@ final class SwipeMusicViewModel: InputOutputViewModel {
     private let musicDeck: any MusicDeck
     private let fetchImageUseCase: FetchImageUseCase
     private let publishCurrentPlaylistUseCase: PublishCurrentPlaylistUseCase
+   
     private let selectedPlaylistPublisher = PassthroughSubject<MolioPlaylist, Never>()
     private let isLoadingPublisher = PassthroughSubject<Bool, Never>()
     private let buttonHighlightPublisher = PassthroughSubject<ButtonHighlight, Never>()

--- a/MolioTests/DefaultPlaylistRepositoryTests.swift
+++ b/MolioTests/DefaultPlaylistRepositoryTests.swift
@@ -25,7 +25,7 @@ final class DefaultPlaylistRepositoryTests: XCTestCase {
         
         let _ = try await repository.saveNewPlaylist(playlistName)
                 
-        let playlist = repository.fetchPlaylist(for: playlistName)
+        let playlist = await repository.fetchPlaylist(for: playlistName)
         
         XCTAssertEqual(playlist?.name, playlistName)
     }
@@ -37,7 +37,7 @@ final class DefaultPlaylistRepositoryTests: XCTestCase {
         let _ = try await repository.saveNewPlaylist(playlistName)
         repository.addMusic(isrc: testISRC, to: playlistName)
         
-        guard let playlist = repository.fetchPlaylist(for: playlistName)else { return }
+        guard let playlist = await repository.fetchPlaylist(for: playlistName)else { return }
         
         let musics = playlist.musicISRCs
         
@@ -45,14 +45,14 @@ final class DefaultPlaylistRepositoryTests: XCTestCase {
         XCTAssertEqual(musics.first, testISRC)
     }
     
-    func testDeleteMusic() {
+    func testDeleteMusic() async {
         let playlistName: String = "AddMusicPlaylist"
         let testISRC = "TEST_ISRC"
         
         repository.addMusic(isrc: testISRC, to: playlistName)
         repository.deleteMusic(isrc: testISRC, in: playlistName)
         
-        let musics = repository.fetchPlaylist(for: playlistName)?.musicISRCs
+        let musics = await repository.fetchPlaylist(for: playlistName)?.musicISRCs
         XCTAssertTrue(musics?.isEmpty ?? false)
     }
     
@@ -63,7 +63,7 @@ final class DefaultPlaylistRepositoryTests: XCTestCase {
         repository.addMusic(isrc: "MUSIC_1", to: playlistName)
         repository.addMusic(isrc: "MUSIC_2", to: playlistName)
 
-        let musics = repository.fetchPlaylist(for: playlistName)?.musicISRCs
+        let musics = await repository.fetchPlaylist(for: playlistName)?.musicISRCs
         XCTAssertEqual(musics?.count, 2)
         XCTAssertEqual(musics?[0], "MUSIC_1")
         XCTAssertEqual(musics?[1], "MUSIC_2")
@@ -78,7 +78,7 @@ final class DefaultPlaylistRepositoryTests: XCTestCase {
 
         repository.moveMusic(isrc: "MUSIC_1", in: playlistName, fromIndex: 0, toIndex: 1)
 
-        let musics = repository.fetchPlaylist(for: playlistName)?.musicISRCs
+        let musics = try await repository.fetchPlaylist(for: playlistName)?.musicISRCs
         XCTAssertEqual(musics?[0], "MUSIC_2")
         XCTAssertEqual(musics?[1], "MUSIC_1")
     }
@@ -86,11 +86,11 @@ final class DefaultPlaylistRepositoryTests: XCTestCase {
     func testDeletePlaylist() async throws {
         let playlistName: String = "DeletePlaylist"
         let _ = try await repository.saveNewPlaylist(playlistName)
-        let id = repository.fetchPlaylist(for: playlistName)?.id
+        let id = try await repository.fetchPlaylist(for: playlistName)?.id
         print(id ?? "nil")
 
         repository.deletePlaylist(playlistName)
-        let currId = repository.fetchPlaylist(for: playlistName)?.id
+        let currId = try await repository.fetchPlaylist(for: playlistName)?.id
 
         XCTAssertEqual(currId, nil)
 


### PR DESCRIPTION
## 1. 배경
- 사용자는 플레이리스트를 선택하여 노래를 저장하고 목록을 들을 수 있습니다.
- CoreData에 저장된 모든 플레이리스트를 보여줍니다.
- UserDefaults에 저장된 현재 선택된 플레이리스트를 체크 표시로 알려줍니다.
- 메인 화면에서 선택된 플레이리스트로 음악을 추가할 수 있습니다.

## 2. 작업 내용
- [x] 플레이리스트 선택 화면 UI 추가
- [x] 플레이리스트 선택 viewModel 추가
- [x] FetchAllPlaylistsUseCase 추가 
- [x] 새로운 플레이리스트 생성하고 다시 선택화면으로 돌아왔을 때 데이터 리로드 기능 추가

## 3. 스크린샷

|   SE   |   15PRO   | 
| :-------------: |  :-------------: |
| <img width=200 src="https://github.com/user-attachments/assets/f62460bd-60e0-4b63-b942-ab25fabbe9b3"> | <img width=200 src="https://github.com/user-attachments/assets/348fde97-89d6-4314-8e07-6788cea92475"> | 

### 시연 영상 ⭐️
- 시나리오 1 : 플레이리스트를 선택합니다. -> 메인 화면에 반영되는 것을 확인합니다.
- 시나리오 2 : 플레이리스트를 새로 생성하면 목록에 반영됩니다.

https://github.com/user-attachments/assets/1e6eee76-9789-4339-ac2c-3608bedc153a



### 4. Issue 번호
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #96
Resolved #99
