### PR TITLE
feat:  CoreData CRUD 구현체 

### DIFF
--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -39,7 +39,7 @@
 		20397E5A2CE5CB3C004ED9CE /* PlaylistRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20397E592CE5CB3C004ED9CE /* PlaylistRepository.swift */; };
 		20397E6A2CE5DCDD004ED9CE /* MolioModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 20397E682CE5DCDD004ED9CE /* MolioModel.xcdatamodeld */; };
 		20397E702CE5DE56004ED9CE /* PersistenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20397E6F2CE5DE56004ED9CE /* PersistenceManager.swift */; };
-		20397E722CE5DFC6004ED9CE /* DefaultPlaylistRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20397E712CE5DFC6004ED9CE /* DefaultPlaylistRepository.swift */; };
+		20397E722CE5DFC6004ED9CE /* CoreDataPlaylistRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20397E712CE5DFC6004ED9CE /* CoreDataPlaylistRepository.swift */; };
 		20397E802CE5FD0A004ED9CE /* DefaultPlaylistRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20397E7F2CE5FD0A004ED9CE /* DefaultPlaylistRepositoryTests.swift */; };
 		205E6A422CF4C4D9005E9150 /* CRUDProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E6A412CF4C4D9005E9150 /* CRUDProtocol.swift */; };
 		2075FEC12CECDDC0009834BE /* CreatePlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC02CECDDC0009834BE /* CreatePlaylistViewModel.swift */; };
@@ -203,7 +203,7 @@
 		20397E592CE5CB3C004ED9CE /* PlaylistRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistRepository.swift; sourceTree = "<group>"; };
 		20397E692CE5DCDD004ED9CE /* MolioModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MolioModel.xcdatamodel; sourceTree = "<group>"; };
 		20397E6F2CE5DE56004ED9CE /* PersistenceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceManager.swift; sourceTree = "<group>"; };
-		20397E712CE5DFC6004ED9CE /* DefaultPlaylistRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPlaylistRepository.swift; sourceTree = "<group>"; };
+		20397E712CE5DFC6004ED9CE /* CoreDataPlaylistRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataPlaylistRepository.swift; sourceTree = "<group>"; };
 		20397E7F2CE5FD0A004ED9CE /* DefaultPlaylistRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPlaylistRepositoryTests.swift; sourceTree = "<group>"; };
 		205E6A412CF4C4D9005E9150 /* CRUDProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRUDProtocol.swift; sourceTree = "<group>"; };
 		2075FEC02CECDDC0009834BE /* CreatePlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePlaylistViewModel.swift; sourceTree = "<group>"; };
@@ -785,7 +785,7 @@
 			children = (
 				F173694A2CDF265900F6242C /* DefaultRecommendedMusicRepository.swift */,
 				F17369672CE36E8F00F6242C /* DefaultImageRepository.swift */,
-				20397E712CE5DFC6004ED9CE /* DefaultPlaylistRepository.swift */,
+				20397E712CE5DFC6004ED9CE /* CoreDataPlaylistRepository.swift */,
 				F1E405A82CECA2D000533701 /* DefaultSignAppleRepository.swift */,
 				2009183D2CEC9C5B0058D8C7 /* DefaultCurrentPlaylistRepository.swift */,
 			);
@@ -1404,7 +1404,7 @@
 				881BBCB52CDCF91B00010A61 /* MockSpotifyTokenProvider.swift in Sources */,
 				F1E405A72CECA22900533701 /* SignAppleRepository.swift in Sources */,
 				F1A3BB792CF0E0BF0062C79C /* ExportPlaylistViewModel.swift in Sources */,
-				20397E722CE5DFC6004ED9CE /* DefaultPlaylistRepository.swift in Sources */,
+				20397E722CE5DFC6004ED9CE /* CoreDataPlaylistRepository.swift in Sources */,
 				881BBCB62CDCF91B00010A61 /* SpotifyAPIService.swift in Sources */,
 				20397E5A2CE5CB3C004ED9CE /* PlaylistRepository.swift in Sources */,
 				200918422CECA79A0058D8C7 /* UserDefaultsError.swift in Sources */,

--- a/Molio/Source/App/AppDelegate.swift
+++ b/Molio/Source/App/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         container.register(RecommendedMusicRepository.self, dependency: DefaultRecommendedMusicRepository())
         container.register(ImageRepository.self, dependency: DefaultImageRepository())
         container.register(CurrentPlaylistRepository.self, dependency: DefaultCurrentPlaylistRepository())
-        container.register(PlaylistRepository.self, dependency: DefaultPlaylistRepository())
+        container.register(PlaylistRepository.self, dependency: MockPlaylistRepository())
         
         // UseCase
         container.register(FetchRecommendedMusicUseCase.self, dependency: DefaultFetchRecommendedMusicUseCase())

--- a/Molio/Source/Data/DataSource/LocalStorage/CoreData/CoreDataError.swift
+++ b/Molio/Source/Data/DataSource/LocalStorage/CoreData/CoreDataError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum CoreDataError: Error {
-    case invalidName
+    case invalidID
     case saveFailed
     case notFound
     case contextUnavailable
@@ -9,7 +9,7 @@ enum CoreDataError: Error {
 
     var localizedDescription: String {
         switch self {
-        case .invalidName:
+        case .invalidID:
             return "The playlist name provided is invalid."
         case .saveFailed:
             return "Failed to save the playlist."

--- a/Molio/Source/Data/DataSource/LocalStorage/CoreData/PersistenceManager.swift
+++ b/Molio/Source/Data/DataSource/LocalStorage/CoreData/PersistenceManager.swift
@@ -18,15 +18,14 @@ final class PersistenceManager {
         return persistenceContainer.viewContext
     }
     
-    func saveContext() {
+    func saveContext() throws {
         let context = persistenceContainer.viewContext
         if context.hasChanges {
             do {
                 try context.save()
             } catch {
                 let nserror = error as NSError
-                fatalError("Unresolved Error \(nserror), \(nserror.userInfo)")
-                // TODO: 사용자 알림창 띄워주기로 변경
+                throw CoreDataError.saveFailed
             }
         }
     }

--- a/Molio/Source/Data/Repository/CoreDataPlaylistRepository.swift
+++ b/Molio/Source/Data/Repository/CoreDataPlaylistRepository.swift
@@ -1,8 +1,138 @@
-import Foundation
 import CoreData
 import Combine
+import Foundation
 
-final class DefaultPlaylistRepository: PlaylistRepository {
+final class CoreDataPlaylistRepository: CRUDProtocol {
+    private let context: NSManagedObjectContext
+    private let fetchRequest: NSFetchRequest<Playlist> = Playlist.fetchRequest()
+    
+    typealias Entity = MolioPlaylist
+    
+    private let alertNotFoundPlaylist: String = "해당 플레이리스트를 못 찾았습니다."
+    private let alertNotFoundMusicsinPlaylist: String = "플레이리스트에 음악이 없습니다."
+    private let alertFailDeletePlaylist: String = "플레이리스트를 삭제할 수 없습니다"
+    
+    
+    // MARK: - CRUD Implementation
+    
+    init (context: NSManagedObjectContext = PersistenceManager.shared.context) {
+        self.context = context
+        ValueTransformer.setValueTransformer(
+            NSSecureUnarchiveFromDataTransformer(),
+            forName: NSValueTransformerName("NSSecureUnarchiveFromDataTransformerName")
+        )
+    }
+    
+    // Create
+    func create(_ entity: MolioPlaylist) async throws {
+        try await context.perform {
+            let playlist = Playlist(context: self.context)
+            
+            playlist.id = entity.id
+            playlist.name = entity.name
+            playlist.createdAt = Date()
+            playlist.musicISRCs = entity.musicISRCs
+            playlist.filters = entity.filters
+            
+            try self.saveContext()
+        }
+    }
+    
+    // Read
+    func read(by id: String) async throws -> MolioPlaylist? {
+        guard let uuid = UUID(uuidString: id) else {
+            throw CoreDataError.invalidID
+        }
+        
+        return await withCheckedContinuation { continuation in
+            context.perform {
+                self.fetchRequest.predicate = NSPredicate(format: "id == %@", uuid as CVarArg)
+                do {
+                    guard let playlist = try self.context.fetch(self.fetchRequest).first else {
+                        continuation.resume(returning: nil)
+                        return
+                    }
+                    
+                    let molioPlaylist = MolioPlaylist(
+                        id: playlist.id,
+                        name: playlist.name,
+                        createdAt: playlist.createdAt,
+                        musicISRCs: playlist.musicISRCs,
+                        filters: playlist.filters
+                    )
+                    
+                    continuation.resume(returning: molioPlaylist)
+                } catch {
+                    print("Failed to read playlist: \(error)")
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+    }
+    
+    func readAll() async throws -> [Entity] {
+        try await context.perform {
+            let playlists = try self.context.fetch(self.fetchRequest)
+            return playlists.map { playlist in
+                MolioPlaylist(id: playlist.id,
+                              name: playlist.name,
+                              createdAt: playlist.createdAt,
+                              musicISRCs: playlist.musicISRCs,
+                              filters: playlist.filters
+                )
+            }
+        }
+    }
+    
+    // Update
+    func update(_ entity: MolioPlaylist) async throws {
+        try await context.perform {
+            self.fetchRequest.predicate = NSPredicate(format: "id == %@", entity.id as CVarArg)
+            do {
+                guard let playlist = try self.context.fetch(self.fetchRequest).first else {
+                    throw CoreDataError.notFound
+                }
+                playlist.name = entity.name
+                playlist.musicISRCs = entity.musicISRCs
+                playlist.filters = entity.filters
+                
+                try self.saveContext()
+            } catch {
+                throw CoreDataError.saveFailed
+            }
+        }
+    }
+    
+    // Delete
+    func delete(by id: String) async throws {
+        guard let uuid = UUID(uuidString: id) else {
+            throw CoreDataError.invalidID
+        }
+        
+        try await context.perform {
+            self.fetchRequest.predicate = NSPredicate(format: "id == %@", uuid as CVarArg)
+            do {
+                guard let playlist = try self.context.fetch(self.fetchRequest).first else {
+                    throw CoreDataError.notFound
+                }
+                self.context.delete(playlist)
+                try self.saveContext()
+            } catch {
+                throw CoreDataError.saveFailed
+            }
+        }
+    }
+    
+    // MARK: - Private Method
+    
+    private func saveContext() throws {
+        try PersistenceManager.shared.saveContext()
+    }
+}
+
+// 수정하기 전의 레포지토리입니다. 삭제하면 빌드가 되지 않아 Mock을 붙여 살려두었습니다.
+// TODO: UseCase 다 작성되고 연결되면 삭제합니다.
+final class MockPlaylistRepository: PlaylistRepository {
     private let context: NSManagedObjectContext
     private var cancellables = Set<AnyCancellable>()
     private let playlistsSubject = PassthroughSubject <[MolioPlaylist], Never>()
@@ -34,14 +164,12 @@ final class DefaultPlaylistRepository: PlaylistRepository {
         guard let playlist = fetchRawPlaylist(for: playlistName) else { return }
         
         playlist.musicISRCs.append(isrc)
-        saveContext()
     }
     
     func deleteMusic(isrc: String, in playlistName: String) {
         guard let playlist = fetchRawPlaylist(for: playlistName) else { return }
         
         playlist.musicISRCs.removeAll { $0 == isrc }
-        saveContext()
     }
     
     func moveMusic(isrc: String, in playlistName: String, fromIndex: Int, toIndex: Int) {
@@ -53,7 +181,6 @@ final class DefaultPlaylistRepository: PlaylistRepository {
             let musicToMove = playlist.musicISRCs.remove(at: fromIndex)
             playlist.musicISRCs.insert(musicToMove, at: toIndex)
             
-            saveContext()
         }
     }
     
@@ -61,7 +188,7 @@ final class DefaultPlaylistRepository: PlaylistRepository {
         do {
             fetchRequest.predicate = nil // 조건 없이 모든 데이터를 가져옴
             let playlists = try context.fetch(fetchRequest)
-
+            
             let molioPlaylists = playlists.map { playlist in
                 MolioPlaylist(
                     id: playlist.id,
@@ -71,7 +198,7 @@ final class DefaultPlaylistRepository: PlaylistRepository {
                     filters: playlist.filters
                 )
             }
-
+            
             return molioPlaylists
         } catch {
             print("Failed to fetch playlists: \(error)")
@@ -101,7 +228,6 @@ final class DefaultPlaylistRepository: PlaylistRepository {
         guard let playlist = fetchRawPlaylist(for: playlistName) else { return }
         
         context.delete(playlist)
-        saveContext()
     }
     
     func fetchPlaylist(for id: String) async -> MolioPlaylist? {
@@ -146,10 +272,6 @@ final class DefaultPlaylistRepository: PlaylistRepository {
         playlistsSubject.send(playlists)
     }
     
-    /// 현재 데이터 저장하기
-    private func saveContext() {
-        PersistenceManager.shared.saveContext()
-    }
     
     private func saveContexts() throws {
         do {

--- a/Molio/Source/Presentation/PlaylistDetail/View/PlaylistDetailView.swift
+++ b/Molio/Source/Presentation/PlaylistDetail/View/PlaylistDetailView.swift
@@ -70,5 +70,5 @@ struct PlaylistDetailView: View {
 }
 
 #Preview {
-    PlaylistDetailView(viewModel: PlaylistDetailViewModel(publishCurrentPlaylistUseCase: DefaultPublishCurrentPlaylistUseCase(playlistRepository: DefaultPlaylistRepository(), currentPlaylistRepository: DefaultCurrentPlaylistRepository()), musicKitService: DefaultMusicKitService()))
+    PlaylistDetailView(viewModel: PlaylistDetailViewModel(publishCurrentPlaylistUseCase: DefaultPublishCurrentPlaylistUseCase(playlistRepository: MockPlaylistRepository(), currentPlaylistRepository: DefaultCurrentPlaylistRepository()), musicKitService: DefaultMusicKitService()))
 }

--- a/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistView.swift
+++ b/Molio/Source/Presentation/SelectPlaylist/SelectPlaylistView.swift
@@ -61,7 +61,7 @@ struct SelectPlaylistView: View {
                             .shadow(radius: 5)
                     }
                     .sheet(isPresented: $isModalPresented) {
-                        CreatePlaylistView(viewModel: CreatePlaylistViewModel(createPlaylistUseCase: DefaultCreatePlaylistUseCase(repository: DefaultPlaylistRepository()), changeCurrentPlaylistUseCase: DefaultChangeCurrentPlaylistUseCase(repository: DefaultCurrentPlaylistRepository())))
+                        CreatePlaylistView(viewModel: CreatePlaylistViewModel(createPlaylistUseCase: DefaultCreatePlaylistUseCase(repository: MockPlaylistRepository()), changeCurrentPlaylistUseCase: DefaultChangeCurrentPlaylistUseCase(repository: DefaultCurrentPlaylistRepository())))
                             .presentationDetents([.fraction(0.5)])
                             .presentationDragIndicator(.visible)
                     }

--- a/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
+++ b/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
@@ -291,7 +291,7 @@ final class SwipeMusicViewController: UIViewController {
         musicPlayer.stop()
         let viewModel = PlaylistDetailViewModel(
             publishCurrentPlaylistUseCase: DefaultPublishCurrentPlaylistUseCase(
-                playlistRepository: DefaultPlaylistRepository(),
+                playlistRepository: MockPlaylistRepository(),
                 currentPlaylistRepository: DefaultCurrentPlaylistRepository()
             ),
             musicKitService: DefaultMusicKitService()

--- a/MolioTests/DefaultPlaylistRepositoryTests.swift
+++ b/MolioTests/DefaultPlaylistRepositoryTests.swift
@@ -2,15 +2,15 @@ import XCTest
 import CoreData
 @testable import Molio
 
-final class DefaultPlaylistRepositoryTests: XCTestCase {
-    var repository: DefaultPlaylistRepository!
+final class CoreDataPlaylistRepositoryTests: XCTestCase {
+    var repository: CoreDataPlaylistRepository!
     var context: NSManagedObjectContext!
     let fetchRequest: NSFetchRequest<Playlist> = Playlist.fetchRequest()
 
     override func setUp() {
         super.setUp()
-        context = TestPersistenceManager.shared.context
-        repository = DefaultPlaylistRepository(context: context)
+        context = TestPersistenceManager.shared.newInMemoryContext()
+        repository = CoreDataPlaylistRepository(context: context)
         
     }
     
@@ -20,111 +20,138 @@ final class DefaultPlaylistRepositoryTests: XCTestCase {
         super.tearDown()
     }
     
-    func testSaveNewPlaylist() async throws {
-        let playlistName: String = "TestPlaylist"
-        
-        let _ = try await repository.saveNewPlaylist(playlistName)
-                
-        guard let playlist = await repository.fetchPlaylist(for: playlistName)else { return }
-                
-        XCTAssertEqual(playlist.name, playlistName)
-    }
-    
-    func testAddMusic() async throws {
-        let playlistName: String = "AddMusicPlaylist"
-        let testISRC = "TEST_ISRC"
-        
-        let _ = try await repository.saveNewPlaylist(playlistName)
-        repository.addMusic(isrc: testISRC, to: playlistName)
-        
-        guard let playlist = await repository.fetchPlaylist(for: playlistName)else { return }
-        
-        let musics = playlist.musicISRCs
-        
-        XCTAssertEqual(musics.count, 1)
-        XCTAssertEqual(musics.first, testISRC)
-    }
-    
-    func testDeleteMusic() async throws {
-        let playlistName: String = "AddMusicPlaylist"
-        let testISRC = "TEST_ISRC"
-        
-        repository.addMusic(isrc: testISRC, to: playlistName)
-        repository.deleteMusic(isrc: testISRC, in: playlistName)
-        
-        guard let playlist = await repository.fetchPlaylist(for: playlistName)else { return }
-        
-        let musics = playlist.musicISRCs
-        
-        XCTAssertTrue(musics.isEmpty ?? false)
-    }
-    
-    func testFetchMusics() async throws {
-        let playlistName: String = "FetchMusicsPlaylist"
-        let _ = try await repository.saveNewPlaylist(playlistName)
-        
-        repository.addMusic(isrc: "MUSIC_1", to: playlistName)
-        repository.addMusic(isrc: "MUSIC_2", to: playlistName)
-        
-        guard let playlist = await repository.fetchPlaylist(for: playlistName)else { return }
-        let musics = playlist.musicISRCs
+    func testCreatePlaylist() async throws {
+        let playlist = MolioPlaylist(
+            id: UUID(),
+            name: "Test Playlist",
+            createdAt: Date(),
+            musicISRCs: ["ISRC001", "ISRC002"],
+            filters: ["Filter1"]
+        )
 
-        XCTAssertEqual(musics.count, 2)
-        XCTAssertEqual(musics[0], "MUSIC_1")
-        XCTAssertEqual(musics[1], "MUSIC_2")
-    }
-    
-    func testMoveMusic() async throws {
-        let playlistName: String = "MoveMusicPlaylist"
-        let _ = try await repository.saveNewPlaylist(playlistName)
-
-        repository.addMusic(isrc: "MUSIC_1", to: playlistName)
-        repository.addMusic(isrc: "MUSIC_2", to: playlistName)
-
-        repository.moveMusic(isrc: "MUSIC_1", in: playlistName, fromIndex: 0, toIndex: 1)
-
+        try await repository.create(playlist)
         
-        guard let playlist = await repository.fetchPlaylist(for: playlistName)else { return }
-        let musics = playlist.musicISRCs
-
-        XCTAssertEqual(musics[0], "MUSIC_2")
-        XCTAssertEqual(musics[1], "MUSIC_1")
+        let fetchedPlaylist = try await repository.read(by: playlist.id.uuidString)
+        
+        XCTAssertNotNil(fetchedPlaylist)
+        XCTAssertEqual(fetchedPlaylist?.name, playlist.name)
+        XCTAssertEqual(fetchedPlaylist?.musicISRCs, playlist.musicISRCs)
+        XCTAssertEqual(fetchedPlaylist?.filters, playlist.filters)
     }
-    
-//    func testDeletePlaylist() async throws {
-//        let playlistName: String = "DeletePlaylist"
-//        let _ = try await repository.saveNewPlaylist(playlistName)
-//        let id = await repository.fetchPlaylist(for: playlistName)?.id
-//        print(id ?? "nil")
-//
-//        repository.deletePlaylist(playlistName)
-//
-//        guard let playlist = await repository.fetchPlaylist(for: playlistName)else { return }
-//        let currId = playlist.id
-//        
-//        XCTAssertEqual(currId, nil)
-//
-//    }
+
+    func testReadPlaylist() async throws {
+        let playlist = MolioPlaylist(
+            id: UUID(),
+            name: "Sample Playlist",
+            createdAt: Date(),
+            musicISRCs: ["ISRC123"],
+            filters: ["Genre1"]
+        )
+
+        try await repository.create(playlist)
+
+        let fetchedPlaylist = try await repository.read(by: playlist.id.uuidString)
+        XCTAssertNotNil(fetchedPlaylist)
+        XCTAssertEqual(fetchedPlaylist?.id, playlist.id)
+        XCTAssertEqual(fetchedPlaylist?.name, playlist.name)
+        XCTAssertEqual(fetchedPlaylist?.musicISRCs, playlist.musicISRCs)
+        XCTAssertEqual(fetchedPlaylist?.filters, playlist.filters)
+    }
+
+    func testReadAllPlaylists() async throws {
+        let playlist1 = MolioPlaylist(
+            id: UUID(),
+            name: "Playlist 1",
+            createdAt: Date(),
+            musicISRCs: ["ISRC001"],
+            filters: ["Filter1"]
+        )
+
+        let playlist2 = MolioPlaylist(
+            id: UUID(),
+            name: "Playlist 2",
+            createdAt: Date(),
+            musicISRCs: ["ISRC002", "ISRC003"],
+            filters: ["Filter2"]
+        )
+
+        try await repository.create(playlist1)
+        try await repository.create(playlist2)
+
+        let playlists = try await repository.readAll()
+        XCTAssertEqual(playlists.count, 2)
+        XCTAssertTrue(playlists.contains { $0.id == playlist1.id })
+        XCTAssertTrue(playlists.contains { $0.id == playlist2.id })
+    }
+
+    func testUpdatePlaylist() async throws {
+        let uuid = UUID()
+        let playlist = MolioPlaylist(
+            id: uuid,
+            name: "Old Playlist Name",
+            createdAt: Date(),
+            musicISRCs: ["ISRC001"],
+            filters: ["Filter1"]
+        )
+
+        try await repository.create(playlist)
+        
+        let updatedPlaylist = MolioPlaylist(
+            id: uuid,
+            name: "Updated Playlist Name",
+            createdAt: Date(),
+            musicISRCs: ["ISRC004"],
+            filters: ["Filter2"]
+        )
+
+        try await repository.update(updatedPlaylist)
+        let fetchedPlaylist = try await repository.read(by: updatedPlaylist.id.uuidString)
+        XCTAssertNotNil(fetchedPlaylist)
+        
+        XCTAssertEqual(fetchedPlaylist?.name, updatedPlaylist.name)
+        XCTAssertEqual(fetchedPlaylist?.musicISRCs, updatedPlaylist.musicISRCs)
+        XCTAssertEqual(fetchedPlaylist?.filters, updatedPlaylist.filters)
+    }
+
+    func testDeletePlaylist() async throws {
+        let playlist = MolioPlaylist(
+            id: UUID(),
+            name: "Playlist to Delete",
+            createdAt: Date(),
+            musicISRCs: ["ISRC001"],
+            filters: ["Filter1"]
+        )
+
+        try await repository.create(playlist)
+
+        try await repository.delete(by: playlist.id.uuidString)
+
+        let fetchedPlaylist = try await repository.read(by: playlist.id.uuidString)
+        XCTAssertNil(fetchedPlaylist)
+    }
 }
 
 final class TestPersistenceManager {
     static let shared = TestPersistenceManager()
     private init() {}
-    
-    lazy var context: NSManagedObjectContext = {
-        let persistentContainer = NSPersistentContainer(name: "MolioModel")
+
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "MolioModel")
         let description = NSPersistentStoreDescription()
         description.type = NSInMemoryStoreType
-        persistentContainer.persistentStoreDescriptions = [description]
+        container.persistentStoreDescriptions = [description]
 
-        persistentContainer.loadPersistentStores { _, error in
+        container.loadPersistentStores { _, error in
             if let error = error {
                 fatalError("Failed to load in-memory Core Data stack: \(error)")
             }
         }
-
-        let context = persistentContainer.viewContext
-        context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy // 병합 정책 설정
-        return context
+        return container
     }()
+
+    func newInMemoryContext() -> NSManagedObjectContext {
+        let context = persistentContainer.newBackgroundContext()
+        context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        return context
+    }
 }


### PR DESCRIPTION
## 1. 배경
- CoreDataPlaylistRepository를 사용하여 CRUD 작업을 수행하기 위해 구현체를 정의합니다.
- 이 작업은 Core Data를 활용하여 플레이리스트 데이터를 관리할 수 있도록 설계된 저장소를 제공합니다.

## 2. 작업 내용
- [x] CoreDataPlaylistRepository 구현체 정의
- [x] CRUDProtocol 준수: create, read, update, delete 메서드 구현.
- [x] 테스트 코드 작성: create, read, update, delete 메서드.
![스크린샷 2024-11-26 오전 1 31 35](https://github.com/user-attachments/assets/a73426e0-6095-401f-8de1-67ee80d03a9d)

### 3. Issue 번호
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #178 

