### PR TITLE
feat: CurrentUserIdUseCase 프로토콜 및 구현체 정의

### DIFF
--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -61,6 +61,9 @@
 		2061490A2CF724EC00FDE96D /* DefaultCommnunityUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149092CF724EC00FDE96D /* DefaultCommnunityUseCaseTests.swift */; };
 		2061490C2CF7258700FDE96D /* MockFollowRelationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2061490B2CF7258700FDE96D /* MockFollowRelationService.swift */; };
 		2061490E2CF7294700FDE96D /* MockAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2061490D2CF7294700FDE96D /* MockAuthService.swift */; };
+		206149182CF845DE00FDE96D /* CurrentUserIdUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149172CF845DE00FDE96D /* CurrentUserIdUseCase.swift */; };
+		2061491A2CF8460800FDE96D /* DefaultCurrentUserIdUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149192CF8460800FDE96D /* DefaultCurrentUserIdUseCase.swift */; };
+		2061491C2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2061491B2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift */; };
 		2075FEC12CECDDC0009834BE /* CreatePlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC02CECDDC0009834BE /* CreatePlaylistViewModel.swift */; };
 		2075FEC42CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC32CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift */; };
 		2075FEC62CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */; };
@@ -285,6 +288,9 @@
 		206149092CF724EC00FDE96D /* DefaultCommnunityUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCommnunityUseCaseTests.swift; sourceTree = "<group>"; };
 		2061490B2CF7258700FDE96D /* MockFollowRelationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFollowRelationService.swift; sourceTree = "<group>"; };
 		2061490D2CF7294700FDE96D /* MockAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthService.swift; sourceTree = "<group>"; };
+		206149172CF845DE00FDE96D /* CurrentUserIdUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserIdUseCase.swift; sourceTree = "<group>"; };
+		206149192CF8460800FDE96D /* DefaultCurrentUserIdUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCurrentUserIdUseCase.swift; sourceTree = "<group>"; };
+		2061491B2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCurrentUserIdUseCaseTests.swift; sourceTree = "<group>"; };
 		2075FEC02CECDDC0009834BE /* CreatePlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePlaylistViewModel.swift; sourceTree = "<group>"; };
 		2075FEC32CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeCurrentPlaylistIUseCase.swift; sourceTree = "<group>"; };
 		2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChangeCurrentPlaylistIUseCase.swift; sourceTree = "<group>"; };
@@ -658,6 +664,15 @@
 			path = CommunityUseCase;
 			sourceTree = "<group>";
 		};
+		206149162CF845CA00FDE96D /* CurrentUserIdUseCase */ = {
+			isa = PBXGroup;
+			children = (
+				206149172CF845DE00FDE96D /* CurrentUserIdUseCase.swift */,
+				206149192CF8460800FDE96D /* DefaultCurrentUserIdUseCase.swift */,
+			);
+			path = CurrentUserIdUseCase;
+			sourceTree = "<group>";
+		};
 		2075FEBF2CECDDA0009834BE /* CreatePlaylist */ = {
 			isa = PBXGroup;
 			children = (
@@ -933,8 +948,8 @@
 		B80970812CDB4472007BC3C4 /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
+				206149162CF845CA00FDE96D /* CurrentUserIdUseCase */,
 				B867AE642CF7266200ACCEDC /* CheckAppleMusicSubscriptionUseCase */,
-				206148F82CF71C3500FDE96D /* UserUseCase */,
 				206149022CF7216800FDE96D /* CommunityUseCase */,
 				B81086EC2CF5E33200403E88 /* AddMusicToPlaylistUseCase */,
 				B876E6412CEF6AF50048CAF9 /* UpdatePlaylistUseCase */,
@@ -1359,6 +1374,7 @@
 				206148EC2CF6F70000FDE96D /* FirebaseUserServiceTests.swift */,
 				206148F62CF7107300FDE96D /* FirebaseFollowRelationServiceTests.swift */,
 				206149092CF724EC00FDE96D /* DefaultCommnunityUseCaseTests.swift */,
+				2061491B2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift */,
 			);
 			path = MolioTests;
 			sourceTree = "<group>";
@@ -1701,6 +1717,7 @@
 				B8D553F22CDFE33A007CCD6D /* SpotifyAuthorizationAPI.swift in Sources */,
 				2010484D2CE9FF570015E800 /* CreatePlaylistView.swift in Sources */,
 				88E483492CEDDD4A003D624E /* PlaylistDetailView.swift in Sources */,
+				2061491A2CF8460800FDE96D /* DefaultCurrentUserIdUseCase.swift in Sources */,
 				88E4834A2CEDDD4A003D624E /* AudioPlayerControlView.swift in Sources */,
 				205E6A442CF563BC005E9150 /* FirebaseStorageManager.swift in Sources */,
 				88E4834B2CEDDD4A003D624E /* MusicListView.swift in Sources */,
@@ -1783,6 +1800,7 @@
 				F1770B2C2CEEFF2200C81272 /* PlaylistImageMusicItem.swift in Sources */,
 				F1A3BB7C2CF0E5070062C79C /* ExportMusicItem.swift in Sources */,
 				F17369642CE36DE300F6242C /* DefaultFetchImageUseCase.swift in Sources */,
+				206149182CF845DE00FDE96D /* CurrentUserIdUseCase.swift in Sources */,
 				F1E405AC2CECA31D00533701 /* AuthService.swift in Sources */,
 				F1E405B02CECA3F500533701 /* FirebaseAuthError.swift in Sources */,
 				20397E6A2CE5DCDD004ED9CE /* MolioModel.xcdatamodeld in Sources */,
@@ -1890,6 +1908,7 @@
 				B8046A4D2CEA62D100933704 /* SpotifyAvailableGenreSeedsDTODummy.swift in Sources */,
 				88C8B5F32CEF296A0079ACB5 /* PublishAllMusicInCurrentPlaylistUseCaseTests.swift in Sources */,
 				88F6E4A92CEC88C700739648 /* PublishCurrentPlaylistUseCaseTests.swift in Sources */,
+				2061491C2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift in Sources */,
 				2061490C2CF7258700FDE96D /* MockFollowRelationService.swift in Sources */,
 				B82B28902CEF846C00D67725 /* MockUpdatePlaylistUseCase.swift in Sources */,
 			);

--- a/Molio/Source/Domain/UseCase/CurrentUserIdUseCase/CurrentUserIdUseCase.swift
+++ b/Molio/Source/Domain/UseCase/CurrentUserIdUseCase/CurrentUserIdUseCase.swift
@@ -1,0 +1,3 @@
+protocol CurrentUserIdUseCase {
+    func execute() throws -> String?
+}

--- a/Molio/Source/Domain/UseCase/CurrentUserIdUseCase/DefaultCurrentUserIdUseCase.swift
+++ b/Molio/Source/Domain/UseCase/CurrentUserIdUseCase/DefaultCurrentUserIdUseCase.swift
@@ -1,0 +1,20 @@
+struct DefaultCurrentUserIdUseCase: CurrentUserIdUseCase {
+    private let authService: AuthService
+    private let usecase: ManageAuthenticationUseCase
+    
+    init(
+        authService: AuthService,
+        usecase: ManageAuthenticationUseCase
+    ) {
+        self.authService = authService
+        self.usecase = usecase
+    }
+    
+    func execute() throws -> String? {
+        if usecase.isLogin() {
+            return try authService.getCurrentID()
+        } else {
+            return nil
+        }
+    }
+}

--- a/Molio/Source/Domain/UseCase/ManageAuthenticationUseCase/DefaultManageAuthenticationUseCase.swift
+++ b/Molio/Source/Domain/UseCase/ManageAuthenticationUseCase/DefaultManageAuthenticationUseCase.swift
@@ -14,6 +14,15 @@ struct DefaultManageAuthenticationUseCase: ManageAuthenticationUseCase {
         setAuthSelection(.selected)
     }
     
+    func isLogin() -> Bool {
+        switch authStateRepository.authMode {
+        case .authenticated:
+            return true
+        case .guest:
+            return false
+        }
+    }
+    
     private func setAuthSelection(_ selection: AuthSelection) {
         authStateRepository.setAuthSelection(selection)
     }

--- a/Molio/Source/Domain/UseCase/ManageAuthenticationUseCase/ManageAuthenticationUseCase.swift
+++ b/Molio/Source/Domain/UseCase/ManageAuthenticationUseCase/ManageAuthenticationUseCase.swift
@@ -1,4 +1,5 @@
 protocol ManageAuthenticationUseCase {
     func isAuthModeSelected() -> Bool
     func setAuthMode(_ mode: AuthMode)
+    func isLogin() -> Bool
 }

--- a/MolioTests/DefaultCurrentUserIdUseCaseTests.swift
+++ b/MolioTests/DefaultCurrentUserIdUseCaseTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+import FirebaseAuth
+@testable import Molio
+
+final class DefaultCurrentUserIdUseCaseTests: XCTestCase {
+    
+    class MockAuthService: AuthService {
+        func getCurrentUser() async throws -> FirebaseAuth.User {
+            throw FirestoreError.documentFetchError
+        }
+        
+        func signInApple(info: Molio.AppleAuthInfo) async throws {
+            
+        }
+        
+        func logout() throws {
+            
+        }
+        
+        func deleteAccount() async throws {
+            
+        }
+        
+        var currentID: String?
+        
+        func getCurrentID() -> String {
+            return currentID ?? ""
+        }
+    }
+    
+    class MockManageAuthenticationUseCase: ManageAuthenticationUseCase {
+        func isAuthModeSelected() -> Bool {
+            return true
+        }
+        
+        func setAuthMode(_ mode: Molio.AuthMode) {
+            
+        }
+        
+        var isLoggedIn: Bool = false
+        
+        func isLogin() -> Bool {
+            return isLoggedIn
+        }
+    }
+    
+    func testExecute_WhenLoggedIn_ReturnsCurrentUserID() throws {
+        let mockAuthService = MockAuthService()
+        let mockUseCase = MockManageAuthenticationUseCase()
+        mockAuthService.currentID = "mockUserID"
+        mockUseCase.isLoggedIn = true
+        
+        let useCase = DefaultCurrentUserIdUseCase(
+            authService: mockAuthService,
+            usecase: mockUseCase
+        )
+        
+        let result = try useCase.execute()
+        
+        XCTAssertEqual(result, "mockUserID", "로그인했을 때에는 아이디를 리턴합니다.")
+    }
+    
+    func testExecute_WhenNotLoggedIn_ReturnsNil() throws {
+        let mockAuthService = MockAuthService()
+        let mockUseCase = MockManageAuthenticationUseCase()
+        mockUseCase.isLoggedIn = false
+        
+        let useCase = DefaultCurrentUserIdUseCase(
+            authService: mockAuthService,
+            usecase: mockUseCase
+        )
+        
+        let result = try useCase.execute()
+        
+        XCTAssertNil(result, "로그인을 하지 않았을 때에는 Nil을 리턴합니다.")
+    }
+}


### PR DESCRIPTION
## 1. 배경
- 로그인 여부에 따라 현재 ID를 알려주는 유스케이스가 필요합니다.
- 플레이리스트 관리 및 불러오기 중에서도 내 플레이리스트 관련 함수 실행 시에 활용할 수 있습니다.

## 2. 작업 내용
- [x] ManageAuthenticationUseCase에 isLogin()함수 추가 : 로그인했는지 여부를 Bool로 리턴합니다
- [x] CurrentUserIdUseCase: execute()시 로그인을 했다면 String 으로 현재 사용자의 id를 리턴합니다.
- [x] CurrentUserIdUseCase 테스트 코드 작성 및 통과
    <img width="452" alt="스크린샷 2024-11-28 오후 3 49 11" src="https://github.com/user-attachments/assets/4d5346e8-bfdb-4667-a559-745b2fc7223f">

## 3. Issue 번호
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #221 
