### PR TITLE
feat: ManagePlaylistUseCase 프로토콜 구현 및 구현체 정의

### DIFF
--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		206149182CF845DE00FDE96D /* CurrentUserIdUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149172CF845DE00FDE96D /* CurrentUserIdUseCase.swift */; };
 		2061491A2CF8460800FDE96D /* DefaultCurrentUserIdUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149192CF8460800FDE96D /* DefaultCurrentUserIdUseCase.swift */; };
 		2061491C2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2061491B2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift */; };
+		2061491F2CF84A2500FDE96D /* ManageMyPlaylistUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2061491E2CF84A2500FDE96D /* ManageMyPlaylistUseCase.swift */; };
 		2075FEC12CECDDC0009834BE /* CreatePlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC02CECDDC0009834BE /* CreatePlaylistViewModel.swift */; };
 		2075FEC42CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC32CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift */; };
 		2075FEC62CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */; };
@@ -291,6 +292,7 @@
 		206149172CF845DE00FDE96D /* CurrentUserIdUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserIdUseCase.swift; sourceTree = "<group>"; };
 		206149192CF8460800FDE96D /* DefaultCurrentUserIdUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCurrentUserIdUseCase.swift; sourceTree = "<group>"; };
 		2061491B2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCurrentUserIdUseCaseTests.swift; sourceTree = "<group>"; };
+		2061491E2CF84A2500FDE96D /* ManageMyPlaylistUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageMyPlaylistUseCase.swift; sourceTree = "<group>"; };
 		2075FEC02CECDDC0009834BE /* CreatePlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePlaylistViewModel.swift; sourceTree = "<group>"; };
 		2075FEC32CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeCurrentPlaylistIUseCase.swift; sourceTree = "<group>"; };
 		2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChangeCurrentPlaylistIUseCase.swift; sourceTree = "<group>"; };
@@ -673,6 +675,14 @@
 			path = CurrentUserIdUseCase;
 			sourceTree = "<group>";
 		};
+		2061491D2CF84A1300FDE96D /* ManageMyPlaylistUseCase */ = {
+			isa = PBXGroup;
+			children = (
+				2061491E2CF84A2500FDE96D /* ManageMyPlaylistUseCase.swift */,
+			);
+			path = ManageMyPlaylistUseCase;
+			sourceTree = "<group>";
+		};
 		2075FEBF2CECDDA0009834BE /* CreatePlaylist */ = {
 			isa = PBXGroup;
 			children = (
@@ -948,6 +958,7 @@
 		B80970812CDB4472007BC3C4 /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
+				2061491D2CF84A1300FDE96D /* ManageMyPlaylistUseCase */,
 				206149162CF845CA00FDE96D /* CurrentUserIdUseCase */,
 				B867AE642CF7266200ACCEDC /* CheckAppleMusicSubscriptionUseCase */,
 				206149022CF7216800FDE96D /* CommunityUseCase */,
@@ -1714,6 +1725,7 @@
 				F173697B2CE4AAC600F6242C /* AudioPlayer.swift in Sources */,
 				F1E4058C2CEB8FC500533701 /* LoginViewController.swift in Sources */,
 				20C655922CEF48D100C60B9C /* DefaultFetchAllPlaylistsUseCase.swift in Sources */,
+				2061491F2CF84A2500FDE96D /* ManageMyPlaylistUseCase.swift in Sources */,
 				B8D553F22CDFE33A007CCD6D /* SpotifyAuthorizationAPI.swift in Sources */,
 				2010484D2CE9FF570015E800 /* CreatePlaylistView.swift in Sources */,
 				88E483492CEDDD4A003D624E /* PlaylistDetailView.swift in Sources */,

--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -65,6 +65,8 @@
 		2061491A2CF8460800FDE96D /* DefaultCurrentUserIdUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149192CF8460800FDE96D /* DefaultCurrentUserIdUseCase.swift */; };
 		2061491C2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2061491B2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift */; };
 		2061491F2CF84A2500FDE96D /* ManageMyPlaylistUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2061491E2CF84A2500FDE96D /* ManageMyPlaylistUseCase.swift */; };
+		206149212CF84A9700FDE96D /* DefaultManageMyPlaylistUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149202CF84A9700FDE96D /* DefaultManageMyPlaylistUseCase.swift */; };
+		206149232CF855D800FDE96D /* DefaultManageMyPlaylistUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149222CF855D800FDE96D /* DefaultManageMyPlaylistUseCaseTests.swift */; };
 		2075FEC12CECDDC0009834BE /* CreatePlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC02CECDDC0009834BE /* CreatePlaylistViewModel.swift */; };
 		2075FEC42CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC32CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift */; };
 		2075FEC62CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */; };
@@ -304,6 +306,8 @@
 		206149192CF8460800FDE96D /* DefaultCurrentUserIdUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCurrentUserIdUseCase.swift; sourceTree = "<group>"; };
 		2061491B2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCurrentUserIdUseCaseTests.swift; sourceTree = "<group>"; };
 		2061491E2CF84A2500FDE96D /* ManageMyPlaylistUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageMyPlaylistUseCase.swift; sourceTree = "<group>"; };
+		206149202CF84A9700FDE96D /* DefaultManageMyPlaylistUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultManageMyPlaylistUseCase.swift; sourceTree = "<group>"; };
+		206149222CF855D800FDE96D /* DefaultManageMyPlaylistUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultManageMyPlaylistUseCaseTests.swift; sourceTree = "<group>"; };
 		2075FEC02CECDDC0009834BE /* CreatePlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePlaylistViewModel.swift; sourceTree = "<group>"; };
 		2075FEC32CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeCurrentPlaylistIUseCase.swift; sourceTree = "<group>"; };
 		2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChangeCurrentPlaylistIUseCase.swift; sourceTree = "<group>"; };
@@ -701,6 +705,7 @@
 			isa = PBXGroup;
 			children = (
 				2061491E2CF84A2500FDE96D /* ManageMyPlaylistUseCase.swift */,
+				206149202CF84A9700FDE96D /* DefaultManageMyPlaylistUseCase.swift */,
 			);
 			path = ManageMyPlaylistUseCase;
 			sourceTree = "<group>";
@@ -1425,6 +1430,7 @@
 				206148F62CF7107300FDE96D /* FirebaseFollowRelationServiceTests.swift */,
 				206149092CF724EC00FDE96D /* DefaultCommnunityUseCaseTests.swift */,
 				2061491B2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift */,
+				206149222CF855D800FDE96D /* DefaultManageMyPlaylistUseCaseTests.swift */,
 			);
 			path = MolioTests;
 			sourceTree = "<group>";
@@ -1843,6 +1849,7 @@
 				B867AE602CF71CF600ACCEDC /* MusicKitError.swift in Sources */,
 				88E4834E2CEDDD66003D624E /* MolioMusic+sample.swift in Sources */,
 				20150EC52CEA36B700FC8883 /* Playlist+CoreDataClass.swift in Sources */,
+				206149212CF84A9700FDE96D /* DefaultManageMyPlaylistUseCase.swift in Sources */,
 				20150EC62CEA36B700FC8883 /* Playlist+CoreDataProperties.swift in Sources */,
 				B8D553EE2CDFE2C0007CCD6D /* HTTPResponseStatusCode.swift in Sources */,
 				88F6E4AB2CEC8B5A00739648 /* PublishCurrentPlaylistUseCase.swift in Sources */,
@@ -1974,6 +1981,7 @@
 				2061491C2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift in Sources */,
 				2061490C2CF7258700FDE96D /* MockFollowRelationService.swift in Sources */,
 				B82B28902CEF846C00D67725 /* MockUpdatePlaylistUseCase.swift in Sources */,
+				206149232CF855D800FDE96D /* DefaultManageMyPlaylistUseCaseTests.swift in Sources */,
 				88E81E2F2CF82D5F00105755 /* DefaultPlaylistRepositoryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Molio/Source/Domain/UseCase/ManageMyPlaylistUseCase/DefaultManageMyPlaylistUseCase.swift
+++ b/Molio/Source/Domain/UseCase/ManageMyPlaylistUseCase/DefaultManageMyPlaylistUseCase.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+final class DefaultManageMyPlaylistUseCase:
+    ManageMyPlaylistUseCase {
+    
+    private let currentUserIdUseCase: CurrentUserIdUseCase
+    private let repository: RealPlaylistRepository
+    
+    init(
+        currentUserIdUseCase: CurrentUserIdUseCase,
+        repository: RealPlaylistRepository
+    ) {
+        self.currentUserIdUseCase = currentUserIdUseCase
+        self.repository = repository
+    }
+    
+    func createPlaylist(playlistName: String) async throws {
+        guard let userID = try currentUserIdUseCase.execute() else { return }
+        
+        let newPlaylistID = UUID()
+        try await repository.createNewPlaylist(userID: userID, playlistID: newPlaylistID, playlistName)
+    }
+    
+    func updatePlaylistName(playlistID: String, name: String) async throws {
+        try await updatePlaylist(playlistID: playlistID, name: name )
+    }
+
+    func updatePlaylistFilter(playlistID: String, filter: MusicFilter) async throws {
+        try await updatePlaylist(playlistID: playlistID, filter: filter)
+    }
+    
+    func deletePlaylist(playlistID: UUID) async throws {
+        guard let userID = try currentUserIdUseCase.execute() else { return }
+        
+        try await repository.deletePlaylist(userID: userID, playlistID)
+    }
+    
+    func addMusic(musicISRC: String, to playlistID: UUID) async throws {
+        guard let userID = try currentUserIdUseCase.execute(),
+              let playlist = try await repository.fetchPlaylist(userID: userID, for: playlistID) else { return }
+        
+        let newMusicISRCs = playlist.musicISRCs + [musicISRC]
+        let newPlaylist = playlist.copy(musicISRCs: newMusicISRCs)
+        try await repository.updatePlaylist(userID: userID, newPlaylist: newPlaylist)
+    }
+    
+    func deleteMusic(musicISRC: String, from playlistID: UUID) async throws {
+        guard let userID = try currentUserIdUseCase.execute(),
+              let playlist = try await repository.fetchPlaylist(userID: userID, for: playlistID) else { return }
+        
+        let newMusicISRCs = playlist.musicISRCs.filter { $0 != musicISRC }
+        let newPlaylist = playlist.copy(musicISRCs: newMusicISRCs)
+        try await repository.updatePlaylist(userID: userID, newPlaylist: newPlaylist)
+    }
+    
+    func moveMusic(musicISRC: String, in playlistID: UUID, fromIndex: Int, toIndex: Int) async throws {
+        if fromIndex == toIndex { return }
+        guard let userID = try currentUserIdUseCase.execute(),
+              let playlist = try await repository.fetchPlaylist(userID: userID, for: playlistID) else {
+            return
+        }
+        
+        guard fromIndex < playlist.musicISRCs.count, toIndex < playlist.musicISRCs.count else {
+            throw PlaylistMusicISRCsError.invalidIndex
+        }
+        
+        var updatedMusicISRCs = playlist.musicISRCs
+        let movedMusic = updatedMusicISRCs.remove(at: fromIndex)
+        
+        if fromIndex > toIndex {
+            updatedMusicISRCs.insert(movedMusic, at: toIndex)
+
+        } else {
+            updatedMusicISRCs.insert(movedMusic, at: toIndex-1)
+        }
+        
+        let updatedPlaylist = playlist.copy(musicISRCs: updatedMusicISRCs)
+        
+        try await repository.updatePlaylist(userID: userID, newPlaylist: updatedPlaylist)
+    }
+    
+    // MARK: - Private Method
+    
+    private func updatePlaylist(playlistID: String, name: String? = nil, musicISRCs: [String]? = nil, filter: MusicFilter? = nil, like: [String]? = nil) async throws {
+        guard let userID = try currentUserIdUseCase.execute(),
+              let playlistUUID = UUID(uuidString: playlistID) else { return }
+        
+        guard let playlist = try await repository.fetchPlaylist(userID: userID, for: playlistUUID) else { return }
+        
+        let newPlaylist = playlist.copy(name: name, musicISRCs: musicISRCs, filter: filter, like: like)
+        try await repository.updatePlaylist(userID: userID, newPlaylist: newPlaylist)
+    }
+}
+
+
+enum PlaylistMusicISRCsError : Error {
+    case invalidIndex
+}

--- a/Molio/Source/Domain/UseCase/ManageMyPlaylistUseCase/ManageMyPlaylistUseCase.swift
+++ b/Molio/Source/Domain/UseCase/ManageMyPlaylistUseCase/ManageMyPlaylistUseCase.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+protocol ManageMyPlaylistUseCase {
+   // 플레이리스트 관리
+    func createPlaylist(playlistName: String) async throws
+    func updatePlaylistName(playlistID: String, name: String) async throws
+    func updatePlaylistFilter(playlistID: String, filter: MusicFilter) async throws
+    func deletePlaylist(playlistID: UUID) async throws
+    
+
+    // 음악 관리
+    func addMusic(musicISRC: String, to playlistID: UUID) async throws
+    func deleteMusic(musicISRC: String, from playlistID: UUID) async throws
+    func moveMusic(musicISRC: String, in playlistID: UUID, fromIndex: Int, toIndex: Int) async throws
+}

--- a/Molio/Source/Domain/UseCase/ManageMyPlaylistUseCase/ManageMyPlaylistUseCase.swift
+++ b/Molio/Source/Domain/UseCase/ManageMyPlaylistUseCase/ManageMyPlaylistUseCase.swift
@@ -7,7 +7,6 @@ protocol ManageMyPlaylistUseCase {
     func updatePlaylistFilter(playlistID: String, filter: MusicFilter) async throws
     func deletePlaylist(playlistID: UUID) async throws
     
-
     // 음악 관리
     func addMusic(musicISRC: String, to playlistID: UUID) async throws
     func deleteMusic(musicISRC: String, from playlistID: UUID) async throws

--- a/MolioTests/DefaultManageMyPlaylistUseCaseTests.swift
+++ b/MolioTests/DefaultManageMyPlaylistUseCaseTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+@testable import Molio
+
+final class DefaultManageMyPlaylistUseCaseTests: XCTestCase {
+    
+    var useCase: DefaultManageMyPlaylistUseCase!
+    var mockCurrentUserIdUseCase: MockCurrentUserIdUseCase!
+    var mockRepository: MockRealPlaylistRepository!
+
+    override func setUp() {
+        super.setUp()
+        // Mock 객체 초기화
+        mockCurrentUserIdUseCase = MockCurrentUserIdUseCase()
+        mockRepository = MockRealPlaylistRepository()
+
+        // UseCase 초기화
+        useCase = DefaultManageMyPlaylistUseCase(
+            currentUserIdUseCase: mockCurrentUserIdUseCase,
+            repository: mockRepository
+        )
+    }
+
+    override func tearDown() {
+        useCase = nil
+        mockCurrentUserIdUseCase = nil
+        mockRepository = nil
+        super.tearDown()
+    }
+
+    // MARK: - 테스트 메서드
+
+    /// 플레이리스트 생성 테스트
+    func testCreatePlaylist() async throws {
+        // Given
+        mockCurrentUserIdUseCase.currentUserID = "testUserID"
+        
+        // When
+        try await useCase.createPlaylist(playlistName: "Test Playlist")
+        
+        // Then
+        XCTAssertTrue(mockRepository.createPlaylistCalled)
+        XCTAssertEqual(mockRepository.createdPlaylistName, "Test Playlist")
+        XCTAssertEqual(mockRepository.createdUserID, "testUserID")
+    }
+
+    /// 플레이리스트 이름 변경 테스트
+    func testUpdatePlaylistName() async throws {
+        // Given
+        mockCurrentUserIdUseCase.currentUserID = "testUserID"
+        let playlistID = UUID()
+        mockRepository.mockPlaylist = MolioPlaylist(
+            id: playlistID,
+            name: "Old Name",
+            createdAt: Date(), musicISRCs: [],
+            filter: MusicFilter(genres: [])
+        )
+        
+        // When
+        try await useCase.updatePlaylistName(playlistID: playlistID.uuidString, name: "New Name")
+        
+        // Then
+        XCTAssertTrue(mockRepository.updatePlaylistCalled)
+        XCTAssertEqual(mockRepository.updatedPlaylist?.name, "New Name")
+    }
+    
+    func testUpdatePlaylistFilter() async throws {
+        // Given
+        mockCurrentUserIdUseCase.currentUserID = "testUserID"
+        let playlistID = UUID()
+        mockRepository.mockPlaylist = MolioPlaylist(
+            id: playlistID,
+            name: "Old Name",
+            createdAt: Date(), musicISRCs: [],
+            filter: MusicFilter(genres: [MusicGenre.acoustic])
+        )
+        
+        // When
+        try await useCase.updatePlaylistFilter(playlistID: playlistID.uuidString, filter: MusicFilter(genres: [MusicGenre.altRock]))
+        
+        // Then
+        XCTAssertTrue(mockRepository.updatePlaylistCalled)
+        XCTAssertEqual(mockRepository.updatedPlaylist?.filter.genres, [MusicGenre.altRock])
+    }
+    
+    /// 플레이리스트 삭제 테스트
+    func testDeletePlaylist() async throws {
+        // Given
+        mockCurrentUserIdUseCase.currentUserID = "testUserID"
+        let playlistID = UUID()
+        
+        // When
+        try await useCase.deletePlaylist(playlistID: playlistID)
+        
+        // Then
+        XCTAssertTrue(mockRepository.deletePlaylistCalled)
+        XCTAssertEqual(mockRepository.deletedPlaylistID, playlistID)
+    }
+    
+    /// 음악 추가 테스트
+    func testAddMusicToPlaylist() async throws {
+        // Given
+        mockCurrentUserIdUseCase.currentUserID = "testUserID"
+        let playlistID = UUID()
+        mockRepository.mockPlaylist = MolioPlaylist(
+            id: playlistID,
+            name: "Playlist Name",
+            createdAt: Date(), musicISRCs: [],
+            filter: MusicFilter(genres: [])
+        )
+        
+        // When
+        try await useCase.addMusic(musicISRC: "ISRC001", to: playlistID)
+        
+        // Then
+        XCTAssertTrue(mockRepository.updatePlaylistCalled)
+        XCTAssertEqual(mockRepository.updatedPlaylist?.musicISRCs, ["ISRC001"])
+    }
+
+    /// 음악 이동 테스트
+    func testMoveMusicInPlaylist_1번_인덱스에서_0번_인덱스로_이동하는_경우() async throws {
+        // Given
+        mockCurrentUserIdUseCase.currentUserID = "testUserID"
+        let playlistID = UUID()
+        mockRepository.mockPlaylist = MolioPlaylist(
+            id: playlistID,
+            name: "Playlist Name",
+            createdAt: Date(), musicISRCs: ["ISRC001", "ISRC002", "ISRC003"],
+            filter: MusicFilter(genres: [])
+        )
+        
+        // When
+        try await useCase.moveMusic(musicISRC: "ISRC002", in: playlistID, fromIndex: 1, toIndex: 0)
+        
+        // Then
+        XCTAssertTrue(mockRepository.updatePlaylistCalled)
+        XCTAssertEqual(mockRepository.updatedPlaylist?.musicISRCs, ["ISRC002", "ISRC001", "ISRC003"])
+    }
+
+    func testMoveMusicInPlaylist_0번_인덱스에서_1번_인덱스로_이동하는_경우() async throws {
+        // Given
+        mockCurrentUserIdUseCase.currentUserID = "testUserID"
+        let playlistID = UUID()
+        mockRepository.mockPlaylist = MolioPlaylist(
+            id: playlistID,
+            name: "Playlist Name",
+            createdAt: Date(), musicISRCs: ["ISRC001", "ISRC002", "ISRC003"],
+            filter: MusicFilter(genres: [])
+        )
+        
+        // When
+        try await useCase.moveMusic(musicISRC: "ISRC002", in: playlistID, fromIndex: 0, toIndex: 1)
+        
+        // Then
+        XCTAssertTrue(mockRepository.updatePlaylistCalled)
+        XCTAssertEqual(mockRepository.updatedPlaylist?.musicISRCs, ["ISRC001", "ISRC002", "ISRC003"])
+    }
+    
+    func testDeleteMusic() async throws {
+        // Given
+        mockCurrentUserIdUseCase.currentUserID = "testUserID"
+        let playlistID = UUID()
+        mockRepository.mockPlaylist = MolioPlaylist(
+            id: playlistID,
+            name: "Playlist Name",
+            createdAt: Date(), musicISRCs: ["ISRC001", "ISRC002", "ISRC003"],
+            filter: MusicFilter(genres: [])
+        )
+        
+        // When
+        try await useCase.deleteMusic(musicISRC: "ISRC001", from: playlistID)
+        
+        // Then
+        XCTAssertEqual(mockRepository.updatedPlaylist?.musicISRCs, ["ISRC002", "ISRC003"])
+    }
+}
+
+final class MockCurrentUserIdUseCase: CurrentUserIdUseCase {
+    var currentUserID: String?
+    func execute() throws -> String? {
+        return currentUserID
+    }
+}

--- a/MolioTests/Test Double/Mock/Repository/MockPlaylistRepository.swift
+++ b/MolioTests/Test Double/Mock/Repository/MockPlaylistRepository.swift
@@ -2,36 +2,43 @@ import Combine
 import Foundation
 @testable import Molio
 
-final class MockPlaylistRepository: PlaylistRepository {
-    var mockPlaylist: [MolioPlaylist] = []
-    var willThrowError: Bool = false
-    
-    var playlistsPublisher: AnyPublisher<[MolioPlaylist], Never> {
-        return Just(mockPlaylist).eraseToAnyPublisher()
+final class MockRealPlaylistRepository: RealPlaylistRepository {
+    var createPlaylistCalled = false
+    var createdPlaylistName: String?
+    var createdUserID: String?
+    var mockPlaylist: MolioPlaylist?
+    var updatePlaylistCalled = false
+    var updatedPlaylist: MolioPlaylist?
+    var deletePlaylistCalled = false
+    var deletedPlaylistID: UUID?
+
+    func addMusic(userID: String?, isrc: String, to playlistID: UUID) async throws {}
+
+    func deleteMusic(userID: String?, isrc: String, in playlistID: UUID) async throws {}
+
+    func moveMusic(userID: String?, isrc: String, in playlistID: UUID, fromIndex: Int, toIndex: Int) async throws {}
+
+    func createNewPlaylist(userID: String?, playlistID: UUID, _ playlistName: String) async throws {
+        createPlaylistCalled = true
+        createdUserID = userID
+        createdPlaylistName = playlistName
     }
-    
-    func addMusic(isrc: String, to playlistID: UUID) async throws {}
-    
-    func deleteMusic(isrc: String, in playlistName: String) {}
-    
-    func moveMusic(isrc: String, in playlistName: String, fromIndex: Int, toIndex: Int) {}
-    
-    func saveNewPlaylist(_ playlistName: String) async throws -> UUID {
-        guard !willThrowError else { throw CoreDataError.saveFailed }
-        return UUID()
+
+    func deletePlaylist(userID: String?, _ playlistID: UUID) async throws {
+        deletePlaylistCalled = true
+        deletedPlaylistID = playlistID
     }
-    
-    func deletePlaylist(_ playlistName: String) {}
-    
-    func fetchPlaylists() -> [MolioPlaylist]? {
-        []
+
+    func fetchPlaylists(userID: String?) async throws -> [MolioPlaylist]? {
+        return nil
     }
-    
-    func fetchPlaylist(for name: String) -> MolioPlaylist? {
-        MolioPlaylist(id: UUID(), name: name, createdAt: Date.now, musicISRCs: [], filter: MusicFilter(genres: []))
+
+    func fetchPlaylist(userID: String?, for playlistID: UUID) async throws -> MolioPlaylist? {
+        return mockPlaylist
     }
-    
-    func updatePlaylist(of id: UUID, name: String?, filter: MusicFilter?, musicISRCs: [String]?, like: [String]?) async throws {
-        guard !willThrowError else { throw CoreDataError.updateFailed }
+
+    func updatePlaylist(userID: String?, newPlaylist: MolioPlaylist) async throws {
+        updatePlaylistCalled = true
+        updatedPlaylist = newPlaylist
     }
 }


### PR DESCRIPTION
## 1. 배경
- 플레이리스트를 관리하기 위한 기능(생성, 수정, 삭제, 음악 추가/삭제 등)을 구현하기 위해 `ManagePlaylistUseCase` 프로토콜과 이를 구현하는 `DefaultManageMyPlaylistUseCase`를 정의하였습니다.
- 현재 사용자의 ID를 활용하여 자신의 플레이리스트를 관리할 수 있도록 설계되었습니다.

## 2. 작업 내용
- [x] `ManagePlaylistUseCase` 프로토콜 구현:
  - [x] 플레이리스트 생성
  - [x] 플레이리스트 이름 수정
  - [x] 플레이리스트 필터 수정
  - [x] 플레이리스트 삭제
  - [x] 음악 추가
  - [x] 음악 삭제
  - [x] 음악 순서 이동
- [x] `DefaultManageMyPlaylistUseCase` 구현체 정의:
  - [x] `RealPlaylistRepository`와 `CurrentUserIdUseCase`를 활용하여 플레이리스트 관리 로직 구현.
  - [x] `updatePlaylist` 메서드를 통해 중복 로직 제거 및 플레이리스트 업데이트 로직 일원화.
- [x]  테스트 코드 추가 및 통과
  ![image](https://github.com/user-attachments/assets/949db3bf-aaaa-4cf5-a6d9-78a0623a0677)

## 3. Issue 번호
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #74