### PR TITLE
feat: UserUseCase 프로토콜 구현 및 구현체 정의

### DIFF
--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -70,6 +70,10 @@
 		206149372CF8675400FDE96D /* CommunityUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149362CF8675400FDE96D /* CommunityUseCase.swift */; };
 		206149392CF8677D00FDE96D /* DefaultCommunityUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149382CF8677D00FDE96D /* DefaultCommunityUseCase.swift */; };
 		2061493B2CF868ED00FDE96D /* DefaultCommnunityUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2061493A2CF868ED00FDE96D /* DefaultCommnunityUseCaseTests.swift */; };
+		2061492E2CF8653400FDE96D /* DefaultUserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2061492B2CF8653300FDE96D /* DefaultUserUseCase.swift */; };
+		2061492F2CF8653400FDE96D /* UserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2061492C2CF8653300FDE96D /* UserUseCase.swift */; };
+		206149312CF8655500FDE96D /* MolioUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149302CF8655500FDE96D /* MolioUser.swift */; };
+		206149332CF8656E00FDE96D /* DefaultUserUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149322CF8656E00FDE96D /* DefaultUserUseCaseTests.swift */; };
 		2075FEC12CECDDC0009834BE /* CreatePlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC02CECDDC0009834BE /* CreatePlaylistViewModel.swift */; };
 		2075FEC42CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC32CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift */; };
 		2075FEC62CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */; };
@@ -314,6 +318,10 @@
 		206149362CF8675400FDE96D /* CommunityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityUseCase.swift; sourceTree = "<group>"; };
 		206149382CF8677D00FDE96D /* DefaultCommunityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCommunityUseCase.swift; sourceTree = "<group>"; };
 		2061493A2CF868ED00FDE96D /* DefaultCommnunityUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCommnunityUseCaseTests.swift; sourceTree = "<group>"; };
+		2061492B2CF8653300FDE96D /* DefaultUserUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultUserUseCase.swift; sourceTree = "<group>"; };
+		2061492C2CF8653300FDE96D /* UserUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserUseCase.swift; sourceTree = "<group>"; };
+		206149302CF8655500FDE96D /* MolioUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MolioUser.swift; sourceTree = "<group>"; };
+		206149322CF8656E00FDE96D /* DefaultUserUseCaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultUserUseCaseTests.swift; sourceTree = "<group>"; };
 		2075FEC02CECDDC0009834BE /* CreatePlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePlaylistViewModel.swift; sourceTree = "<group>"; };
 		2075FEC32CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeCurrentPlaylistIUseCase.swift; sourceTree = "<group>"; };
 		2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChangeCurrentPlaylistIUseCase.swift; sourceTree = "<group>"; };
@@ -723,6 +731,13 @@
 				206149382CF8677D00FDE96D /* DefaultCommunityUseCase.swift */,
 			);
 			path = CommunityUseCase;
+		2061492D2CF8653300FDE96D /* UserUseCase */ = {
+			isa = PBXGroup;
+			children = (
+				2061492B2CF8653300FDE96D /* DefaultUserUseCase.swift */,
+				2061492C2CF8653300FDE96D /* UserUseCase.swift */,
+			);
+			path = UserUseCase;
 			sourceTree = "<group>";
 		};
 		2075FEBF2CECDDA0009834BE /* CreatePlaylist */ = {
@@ -764,6 +779,7 @@
 		881622722CE3BAB900E81EA0 /* MusicDeck */ = {
 			isa = PBXGroup;
 			children = (
+				206149302CF8655500FDE96D /* MolioUser.swift */,
 				881622682CE3671400E81EA0 /* RandomMusicDeck.swift */,
 				8816226C2CE3B11C00E81EA0 /* MusicDeck.swift */,
 			);
@@ -1011,6 +1027,7 @@
 			children = (
 				2061491D2CF84A1300FDE96D /* ManageMyPlaylistUseCase */,
 				206149352CF8674800FDE96D /* CommunityUseCase */,
+				2061492D2CF8653300FDE96D /* UserUseCase */,
 				206149162CF845CA00FDE96D /* CurrentUserIdUseCase */,
 				B867AE642CF7266200ACCEDC /* CheckAppleMusicSubscriptionUseCase */,
 				206149022CF7216800FDE96D /* FollowRelationUseCase */,
@@ -1448,6 +1465,7 @@
 				2061491B2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift */,
 				206149222CF855D800FDE96D /* DefaultManageMyPlaylistUseCaseTests.swift */,
 				2061493A2CF868ED00FDE96D /* DefaultCommnunityUseCaseTests.swift */,
+				206149322CF8656E00FDE96D /* DefaultUserUseCaseTests.swift */,
 			);
 			path = MolioTests;
 			sourceTree = "<group>";
@@ -1818,6 +1836,7 @@
 				F173694B2CDF265900F6242C /* DefaultRecommendedMusicRepository.swift in Sources */,
 				F135BCEE2CF440B5006C6C4F /* AuthStateRepository.swift in Sources */,
 				F1E405A52CECA19200533701 /* DefaultSignInAppleUseCase.swift in Sources */,
+				2061492F2CF8653400FDE96D /* UserUseCase.swift in Sources */,
 				885D1B632CF4D28700F532E0 /* MolioPlaylist+FirestoreEntity.swift in Sources */,
 				B8378BC22CF6DD0200737125 /* ExportPlatform.swift in Sources */,
 				206149392CF8677D00FDE96D /* DefaultCommunityUseCase.swift in Sources */,
@@ -1840,9 +1859,11 @@
 				B8D554062CE0ED2C007CCD6D /* SpotifyAPI.swift in Sources */,
 				B8046A442CE9250B00933704 /* MusicGenre.swift in Sources */,
 				B8D554C82CE34A47007CCD6D /* String+Extension.swift in Sources */,
+				2061492E2CF8653400FDE96D /* DefaultUserUseCase.swift in Sources */,
 				881BBCC12CDCF97900010A61 /* MusicFilter.swift in Sources */,
 				885D1B592CF4C7E400F532E0 /* FirestoreManager.swift in Sources */,
 				2010485B2CEA2B1B0015E800 /* DefaultCreatePlaylistUseCase.swift in Sources */,
+				206149312CF8655500FDE96D /* MolioUser.swift in Sources */,
 				F135BCE82CF43E13006C6C4F /* AuthMode.swift in Sources */,
 				201048512CEA23190015E800 /* addGradientBackground.swift in Sources */,
 				205E6A5D2CF5D7EB005E9150 /* AuthLocalStorage.swift in Sources */,
@@ -1997,6 +2018,7 @@
 				88E81E2D2CF82C8100105755 /* MockPlaylistStorage.swift in Sources */,
 				B8046A4D2CEA62D100933704 /* SpotifyAvailableGenreSeedsDTODummy.swift in Sources */,
 				88C8B5F32CEF296A0079ACB5 /* PublishAllMusicInCurrentPlaylistUseCaseTests.swift in Sources */,
+				206149332CF8656E00FDE96D /* DefaultUserUseCaseTests.swift in Sources */,
 				88F6E4A92CEC88C700739648 /* PublishCurrentPlaylistUseCaseTests.swift in Sources */,
 				2061491C2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift in Sources */,
 				2061490C2CF7258700FDE96D /* MockFollowRelationService.swift in Sources */,

--- a/Molio/Source/Domain/Entity/MusicDeck/MolioUser.swift
+++ b/Molio/Source/Domain/Entity/MusicDeck/MolioUser.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct MolioUser: Identifiable {
+    let id: String          // 유저의 고유 ID
+    var name: String      // 유저 닉네임
+    var profileImageURL: URL? // 유저의 사진 URL
+    var description: String?  // 유저의 한 줄 설명
+}

--- a/Molio/Source/Domain/UseCase/UserUseCase/DefaultUserUseCase.swift
+++ b/Molio/Source/Domain/UseCase/UserUseCase/DefaultUserUseCase.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+final class DefaultUserUseCase: UserUseCase {
+    private let service: UserService
+    
+    init(
+        service: UserService
+    ) {
+        self.service = service
+    }
+    
+    func createUser(userID: String, userName: String, imageURL: URL?, description: String?) async throws {
+        let newUser = MolioUserDTO(
+            id: userID,
+            name: userName,
+            profileImageURL: imageURL?.absoluteString,
+            description: description
+        )
+        try await service.createUser(newUser)
+    }
+    
+func fetchUser(userID: String) async throws -> MolioUser {
+    let userDTO = try await service.readUser(userID: userID)
+
+    let profileImageURL: URL?
+    if let urlString = userDTO.profileImageURL {
+        profileImageURL = URL(string: urlString)
+    } else {
+        profileImageURL = nil
+    }
+
+    let user = MolioUser(
+        id: userDTO.id,
+        name: userDTO.name,
+        profileImageURL: profileImageURL,
+        description: userDTO.description
+    )
+
+    return user
+}
+    
+    func updateUserName(userID: String, newName: String) async throws {
+        let user = try await service.readUser(userID: userID)
+        let newUser = MolioUserDTO(
+            id: user.id,
+            name: newName,
+            profileImageURL: user.profileImageURL,
+            description: user.description
+        )
+        try await service.updateUser(newUser)
+    }
+    
+    func updateUserDescription(userID: String, newDescription: String?) async throws {
+        let user = try await service.readUser(userID: userID)
+        let newUser = MolioUserDTO(
+            id: user.id,
+            name: user.name,
+            profileImageURL: user.profileImageURL,
+            description: newDescription
+        )
+        try await service.updateUser(newUser)
+    }
+    
+    func updateUserImage(userID: String, newImageURL: URL?) async throws {
+        let user = try await service.readUser(userID: userID)
+        let newUser = MolioUserDTO(
+            id: user.id,
+            name: user.name,
+            profileImageURL: newImageURL?.absoluteString,
+            description: user.description
+        )
+        try await service.updateUser(newUser)
+    }
+    
+    func deleteUser(userID: String) async throws {
+        try await service.deleteUser(userID: userID)
+    }
+}

--- a/Molio/Source/Domain/UseCase/UserUseCase/UserUseCase.swift
+++ b/Molio/Source/Domain/UseCase/UserUseCase/UserUseCase.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+protocol UserUseCase {
+    func createUser(userID: String, userName: String, imageURL: URL?, description: String?) async throws
+    func fetchUser(userID: String) async throws -> MolioUser
+    func updateUserName(userID: String, newName: String) async throws
+    func updateUserDescription(userID: String, newDescription: String?) async throws
+    func updateUserImage(userID: String, newImageURL: URL?) async throws
+    func deleteUser(userID: String) async throws
+}

--- a/MolioTests/DefaultUserUseCaseTests.swift
+++ b/MolioTests/DefaultUserUseCaseTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+@testable import Molio
+
+final class DefaultUserUseCaseTests: XCTestCase {
+    var userUseCase: DefaultUserUseCase!
+    var mockService: MockUserService!
+    
+    override func setUp() {
+        super.setUp()
+        mockService = MockUserService()
+        userUseCase = DefaultUserUseCase(service: mockService)
+    }
+    
+    override func tearDown() {
+        userUseCase = nil
+        mockService = nil
+        super.tearDown()
+    }
+    
+    func testCreateUser() async throws {
+        let userID = "testUserID"
+        let userName = "Test User"
+        let imageURL = URL(string: "https://example.com/image.jpg")
+        let description = "This is a test user."
+
+        try await userUseCase.createUser(userID: userID, userName: userName, imageURL: imageURL, description: description)
+        
+        XCTAssertEqual(mockService.createdUser?.id, userID)
+        XCTAssertEqual(mockService.createdUser?.name, userName)
+        XCTAssertEqual(mockService.createdUser?.profileImageURL, imageURL?.absoluteString)
+        XCTAssertEqual(mockService.createdUser?.description, description)
+    }
+    
+    func testFetchUser() async throws {
+        let expectedUser = MolioUserDTO(
+            id: "testUserID",
+            name: "Test User",
+            profileImageURL: "https://example.com/image.jpg",
+            description: "Test Description"
+        )
+        
+        mockService.mockedUser = expectedUser
+        
+        let user = try await userUseCase.fetchUser(userID: "testUserID")
+        
+        XCTAssertEqual(user.id, expectedUser.id)
+        XCTAssertEqual(user.name, expectedUser.name)
+        XCTAssertEqual(user.profileImageURL?.absoluteString, expectedUser.profileImageURL)
+        XCTAssertEqual(user.description, expectedUser.description)
+    }
+    
+    func testUpdateUserName() async throws {
+        let userID = "testUserID"
+        let newName = "Updated Name"
+        
+        let existingUser = MolioUserDTO(
+            id: userID,
+            name: "Old Name",
+            profileImageURL: "https://example.com/image.jpg",
+            description: "Test Description"
+        )
+        
+        mockService.mockedUser = existingUser
+        
+        try await userUseCase.updateUserName(userID: userID, newName: newName)
+        
+        XCTAssertEqual(mockService.updatedUser?.name, newName)
+        XCTAssertEqual(mockService.updatedUser?.profileImageURL, existingUser.profileImageURL)
+        XCTAssertEqual(mockService.updatedUser?.description, existingUser.description)
+    }
+    
+    func testUpdateUserDescription() async throws {
+        let userID = "testUserID"
+        let newDescription = "Updated Description"
+        
+        let existingUser = MolioUserDTO(
+            id: userID,
+            name: "Test User",
+            profileImageURL: "https://example.com/image.jpg",
+            description: "Old Description"
+        )
+        
+        mockService.mockedUser = existingUser
+        
+        try await userUseCase.updateUserDescription(userID: userID, newDescription: newDescription)
+        
+        XCTAssertEqual(mockService.updatedUser?.description, newDescription)
+        XCTAssertEqual(mockService.updatedUser?.name, existingUser.name)
+        XCTAssertEqual(mockService.updatedUser?.profileImageURL, existingUser.profileImageURL)
+    }
+    
+    func testUpdateUserImage() async throws {
+        let userID = "testUserID"
+        let newImageURL = URL(string: "https://example.com/newImage.jpg")
+        
+        let existingUser = MolioUserDTO(
+            id: userID,
+            name: "Test User",
+            profileImageURL: "https://example.com/image.jpg",
+            description: "Test Description"
+        )
+        
+        mockService.mockedUser = existingUser
+        
+        try await userUseCase.updateUserImage(userID: userID, newImageURL: newImageURL)
+        
+        XCTAssertEqual(mockService.updatedUser?.profileImageURL, newImageURL?.absoluteString)
+        XCTAssertEqual(mockService.updatedUser?.name, existingUser.name)
+        XCTAssertEqual(mockService.updatedUser?.description, existingUser.description)
+    }
+    
+    func testDeleteUser() async throws {
+        let userID = "testUserID"
+        
+        try await userUseCase.deleteUser(userID: userID)
+        
+        XCTAssertEqual(mockService.deletedUserID, userID)
+    }
+}
+
+final class MockUserService: UserService {
+    var createdUser: MolioUserDTO?
+    var mockedUser: MolioUserDTO?
+    var updatedUser: MolioUserDTO?
+    var deletedUserID: String?
+    
+    func createUser(_ user: MolioUserDTO) async throws {
+        createdUser = user
+    }
+    
+    func readUser(userID: String) async throws -> MolioUserDTO {
+        guard let mockedUser = mockedUser else {
+            throw NSError(domain: "User not found", code: 404, userInfo: nil)
+        }
+        return mockedUser
+    }
+    
+    func updateUser(_ user: MolioUserDTO) async throws {
+        updatedUser = user
+    }
+    
+    func deleteUser(userID: String) async throws {
+        deletedUserID = userID
+    }
+}


### PR DESCRIPTION
## 1. 배경
- Firestore 기반으로 사용자 데이터를 관리하기 위해 FirebaseUserService를 구현.
- 비동기 프로그래밍 (async/await)을 적용하여 Firebase와 통신하는 메서드 작성.

## 2. 작업 내용
- [x] MolioUserDTO 추가 (to Dictionary() 기능 포함) 
- [x] createUser: Firestore에 새로운 사용자 데이터를 생성하는 메서드 구현.
- [x] readUser: Firestore에서 사용자 데이터를 읽어오는 메서드 구현.
- [x] updateUser: Firestore에 저장된 사용자 데이터를 업데이트하는 메서드 구현.
- [x] deleteUser: Firestore에서 사용자 데이터를 삭제하는 메서드 구현.
- [x] Firebase 초기화 검사를 추가하여 중복 초기화 방지.
- [x] 테스트 작성 및 완료 
  ![image](https://github.com/user-attachments/assets/9c8734aa-e752-40dd-a3ab-521b431c31d8)

## 3. Issue 번호
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #201 

## 4. 참고자료
[FireStore 데이터 소스 관련 자료](https://cloud.google.com/firestore/docs/manage-data/add-data?hl=ko)