### PR TITLE
feat: UserUseCase 프로토콜 구현 및 구현체 정의

### DIFF
--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -70,6 +70,10 @@
 		206149372CF8675400FDE96D /* CommunityUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149362CF8675400FDE96D /* CommunityUseCase.swift */; };
 		206149392CF8677D00FDE96D /* DefaultCommunityUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149382CF8677D00FDE96D /* DefaultCommunityUseCase.swift */; };
 		2061493B2CF868ED00FDE96D /* DefaultCommnunityUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2061493A2CF868ED00FDE96D /* DefaultCommnunityUseCaseTests.swift */; };
+		206149432CF87FFA00FDE96D /* DefaultUserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149402CF87FFA00FDE96D /* DefaultUserUseCase.swift */; };
+		206149442CF87FFA00FDE96D /* UserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149412CF87FFA00FDE96D /* UserUseCase.swift */; };
+		206149462CF8800500FDE96D /* MolioUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149452CF8800500FDE96D /* MolioUser.swift */; };
+		206149482CF8801600FDE96D /* DefaultUserUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149472CF8801600FDE96D /* DefaultUserUseCaseTests.swift */; };
 		2075FEC12CECDDC0009834BE /* CreatePlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC02CECDDC0009834BE /* CreatePlaylistViewModel.swift */; };
 		2075FEC42CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC32CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift */; };
 		2075FEC62CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */; };
@@ -314,6 +318,10 @@
 		206149362CF8675400FDE96D /* CommunityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityUseCase.swift; sourceTree = "<group>"; };
 		206149382CF8677D00FDE96D /* DefaultCommunityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCommunityUseCase.swift; sourceTree = "<group>"; };
 		2061493A2CF868ED00FDE96D /* DefaultCommnunityUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCommnunityUseCaseTests.swift; sourceTree = "<group>"; };
+		206149402CF87FFA00FDE96D /* DefaultUserUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultUserUseCase.swift; sourceTree = "<group>"; };
+		206149412CF87FFA00FDE96D /* UserUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserUseCase.swift; sourceTree = "<group>"; };
+		206149452CF8800500FDE96D /* MolioUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MolioUser.swift; sourceTree = "<group>"; };
+		206149472CF8801600FDE96D /* DefaultUserUseCaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultUserUseCaseTests.swift; sourceTree = "<group>"; };
 		2075FEC02CECDDC0009834BE /* CreatePlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePlaylistViewModel.swift; sourceTree = "<group>"; };
 		2075FEC32CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeCurrentPlaylistIUseCase.swift; sourceTree = "<group>"; };
 		2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChangeCurrentPlaylistIUseCase.swift; sourceTree = "<group>"; };
@@ -725,6 +733,15 @@
 			path = CommunityUseCase;
 			sourceTree = "<group>";
 		};
+		206149422CF87FFA00FDE96D /* UserUseCase */ = {
+			isa = PBXGroup;
+			children = (
+				206149402CF87FFA00FDE96D /* DefaultUserUseCase.swift */,
+				206149412CF87FFA00FDE96D /* UserUseCase.swift */,
+			);
+			path = UserUseCase;
+			sourceTree = "<group>";
+		};
 		2075FEBF2CECDDA0009834BE /* CreatePlaylist */ = {
 			isa = PBXGroup;
 			children = (
@@ -1009,6 +1026,7 @@
 		B80970812CDB4472007BC3C4 /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
+				206149422CF87FFA00FDE96D /* UserUseCase */,
 				2061491D2CF84A1300FDE96D /* ManageMyPlaylistUseCase */,
 				206149352CF8674800FDE96D /* CommunityUseCase */,
 				206149162CF845CA00FDE96D /* CurrentUserIdUseCase */,
@@ -1047,6 +1065,7 @@
 		B80970832CDB44DB007BC3C4 /* Entity */ = {
 			isa = PBXGroup;
 			children = (
+				206149452CF8800500FDE96D /* MolioUser.swift */,
 				F1E4059C2CEC935B00533701 /* Auth */,
 				881622722CE3BAB900E81EA0 /* MusicDeck */,
 				2008FCBA2CE8A1B90060F3B8 /* MolioPlaylist.swift */,
@@ -1448,6 +1467,7 @@
 				2061491B2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift */,
 				206149222CF855D800FDE96D /* DefaultManageMyPlaylistUseCaseTests.swift */,
 				2061493A2CF868ED00FDE96D /* DefaultCommnunityUseCaseTests.swift */,
+				206149472CF8801600FDE96D /* DefaultUserUseCaseTests.swift */,
 			);
 			path = MolioTests;
 			sourceTree = "<group>";
@@ -1797,6 +1817,7 @@
 				88E4834A2CEDDD4A003D624E /* AudioPlayerControlView.swift in Sources */,
 				205E6A442CF563BC005E9150 /* FirebaseStorageManager.swift in Sources */,
 				88E4834B2CEDDD4A003D624E /* MusicListView.swift in Sources */,
+				206149432CF87FFA00FDE96D /* DefaultUserUseCase.swift in Sources */,
 				88E4834C2CEDDD4A003D624E /* MusicCellView.swift in Sources */,
 				B867AE632CF7240900ACCEDC /* PlatformSelectionViewController.swift in Sources */,
 				F12054EC2CF802B80040A69C /* SettingViewController.swift in Sources */,
@@ -1848,6 +1869,8 @@
 				205E6A5D2CF5D7EB005E9150 /* AuthLocalStorage.swift in Sources */,
 				20397E512CE33C03004ED9CE /* SwipeMusicPlayer.swift in Sources */,
 				F1E405A32CEC9E9B00533701 /* SignInAppleUseCase.swift in Sources */,
+				206149462CF8800500FDE96D /* MolioUser.swift in Sources */,
+				206149442CF87FFA00FDE96D /* UserUseCase.swift in Sources */,
 				B88F80C22CE4B23B000480E6 /* TagLayout.swift in Sources */,
 				B8D553EC2CDFE29D007CCD6D /* NetworkError.swift in Sources */,
 				881BBCC22CDCF97900010A61 /* RecommendationRequestEntity.swift in Sources */,
@@ -1996,6 +2019,7 @@
 				88E81E2B2CF82B8E00105755 /* MockPlaylistService.swift in Sources */,
 				88E81E2D2CF82C8100105755 /* MockPlaylistStorage.swift in Sources */,
 				B8046A4D2CEA62D100933704 /* SpotifyAvailableGenreSeedsDTODummy.swift in Sources */,
+				206149482CF8801600FDE96D /* DefaultUserUseCaseTests.swift in Sources */,
 				88C8B5F32CEF296A0079ACB5 /* PublishAllMusicInCurrentPlaylistUseCaseTests.swift in Sources */,
 				88F6E4A92CEC88C700739648 /* PublishCurrentPlaylistUseCaseTests.swift in Sources */,
 				2061491C2CF846B400FDE96D /* DefaultCurrentUserIdUseCaseTests.swift in Sources */,

--- a/Molio/Source/Domain/Entity/MolioUser.swift
+++ b/Molio/Source/Domain/Entity/MolioUser.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct MolioUser: Identifiable {
+    let id: String          // 유저의 고유 ID
+    var name: String      // 유저 닉네임
+    var profileImageURL: URL? // 유저의 사진 URL
+    var description: String?  // 유저의 한 줄 설명
+}

--- a/Molio/Source/Domain/UseCase/UserUseCase/DefaultUserUseCase.swift
+++ b/Molio/Source/Domain/UseCase/UserUseCase/DefaultUserUseCase.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+final class DefaultUserUseCase: UserUseCase {
+    private let service: UserService
+    
+    init(
+        service: UserService
+    ) {
+        self.service = service
+    }
+    
+    func createUser(userID: String, userName: String, imageURL: URL?, description: String?) async throws {
+        let newUser = MolioUserDTO(
+            id: userID,
+            name: userName,
+            profileImageURL: imageURL?.absoluteString,
+            description: description
+        )
+        try await service.createUser(newUser)
+    }
+    
+func fetchUser(userID: String) async throws -> MolioUser {
+    let userDTO = try await service.readUser(userID: userID)
+
+    let profileImageURL: URL?
+    if let urlString = userDTO.profileImageURL {
+        profileImageURL = URL(string: urlString)
+    } else {
+        profileImageURL = nil
+    }
+
+    let user = MolioUser(
+        id: userDTO.id,
+        name: userDTO.name,
+        profileImageURL: profileImageURL,
+        description: userDTO.description
+    )
+
+    return user
+}
+    
+    func updateUserName(userID: String, newName: String) async throws {
+        let user = try await service.readUser(userID: userID)
+        let newUser = MolioUserDTO(
+            id: user.id,
+            name: newName,
+            profileImageURL: user.profileImageURL,
+            description: user.description
+        )
+        try await service.updateUser(newUser)
+    }
+    
+    func updateUserDescription(userID: String, newDescription: String?) async throws {
+        let user = try await service.readUser(userID: userID)
+        let newUser = MolioUserDTO(
+            id: user.id,
+            name: user.name,
+            profileImageURL: user.profileImageURL,
+            description: newDescription
+        )
+        try await service.updateUser(newUser)
+    }
+    
+    func updateUserImage(userID: String, newImageURL: URL?) async throws {
+        let user = try await service.readUser(userID: userID)
+        let newUser = MolioUserDTO(
+            id: user.id,
+            name: user.name,
+            profileImageURL: newImageURL?.absoluteString,
+            description: user.description
+        )
+        try await service.updateUser(newUser)
+    }
+    
+    func deleteUser(userID: String) async throws {
+        try await service.deleteUser(userID: userID)
+    }
+}

--- a/Molio/Source/Domain/UseCase/UserUseCase/UserUseCase.swift
+++ b/Molio/Source/Domain/UseCase/UserUseCase/UserUseCase.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+protocol UserUseCase {
+    func createUser(userID: String, userName: String, imageURL: URL?, description: String?) async throws
+    func fetchUser(userID: String) async throws -> MolioUser
+    func updateUserName(userID: String, newName: String) async throws
+    func updateUserDescription(userID: String, newDescription: String?) async throws
+    func updateUserImage(userID: String, newImageURL: URL?) async throws
+    func deleteUser(userID: String) async throws
+}

--- a/MolioTests/DefaultUserUseCaseTests.swift
+++ b/MolioTests/DefaultUserUseCaseTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+@testable import Molio
+
+final class DefaultUserUseCaseTests: XCTestCase {
+    var userUseCase: DefaultUserUseCase!
+    var mockService: MockUserService!
+    
+    override func setUp() {
+        super.setUp()
+        mockService = MockUserService()
+        userUseCase = DefaultUserUseCase(service: mockService)
+    }
+    
+    override func tearDown() {
+        userUseCase = nil
+        mockService = nil
+        super.tearDown()
+    }
+    
+    func testCreateUser() async throws {
+        let userID = "testUserID"
+        let userName = "Test User"
+        let imageURL = URL(string: "https://example.com/image.jpg")
+        let description = "This is a test user."
+
+        try await userUseCase.createUser(userID: userID, userName: userName, imageURL: imageURL, description: description)
+        
+        XCTAssertEqual(mockService.createdUser?.id, userID)
+        XCTAssertEqual(mockService.createdUser?.name, userName)
+        XCTAssertEqual(mockService.createdUser?.profileImageURL, imageURL?.absoluteString)
+        XCTAssertEqual(mockService.createdUser?.description, description)
+    }
+    
+    func testFetchUser() async throws {
+        let expectedUser = MolioUserDTO(
+            id: "testUserID",
+            name: "Test User",
+            profileImageURL: "https://example.com/image.jpg",
+            description: "Test Description"
+        )
+        
+        mockService.mockedUser = expectedUser
+        
+        let user = try await userUseCase.fetchUser(userID: "testUserID")
+        
+        XCTAssertEqual(user.id, expectedUser.id)
+        XCTAssertEqual(user.name, expectedUser.name)
+        XCTAssertEqual(user.profileImageURL?.absoluteString, expectedUser.profileImageURL)
+        XCTAssertEqual(user.description, expectedUser.description)
+    }
+    
+    func testUpdateUserName() async throws {
+        let userID = "testUserID"
+        let newName = "Updated Name"
+        
+        let existingUser = MolioUserDTO(
+            id: userID,
+            name: "Old Name",
+            profileImageURL: "https://example.com/image.jpg",
+            description: "Test Description"
+        )
+        
+        mockService.mockedUser = existingUser
+        
+        try await userUseCase.updateUserName(userID: userID, newName: newName)
+        
+        XCTAssertEqual(mockService.updatedUser?.name, newName)
+        XCTAssertEqual(mockService.updatedUser?.profileImageURL, existingUser.profileImageURL)
+        XCTAssertEqual(mockService.updatedUser?.description, existingUser.description)
+    }
+    
+    func testUpdateUserDescription() async throws {
+        let userID = "testUserID"
+        let newDescription = "Updated Description"
+        
+        let existingUser = MolioUserDTO(
+            id: userID,
+            name: "Test User",
+            profileImageURL: "https://example.com/image.jpg",
+            description: "Old Description"
+        )
+        
+        mockService.mockedUser = existingUser
+        
+        try await userUseCase.updateUserDescription(userID: userID, newDescription: newDescription)
+        
+        XCTAssertEqual(mockService.updatedUser?.description, newDescription)
+        XCTAssertEqual(mockService.updatedUser?.name, existingUser.name)
+        XCTAssertEqual(mockService.updatedUser?.profileImageURL, existingUser.profileImageURL)
+    }
+    
+    func testUpdateUserImage() async throws {
+        let userID = "testUserID"
+        let newImageURL = URL(string: "https://example.com/newImage.jpg")
+        
+        let existingUser = MolioUserDTO(
+            id: userID,
+            name: "Test User",
+            profileImageURL: "https://example.com/image.jpg",
+            description: "Test Description"
+        )
+        
+        mockService.mockedUser = existingUser
+        
+        try await userUseCase.updateUserImage(userID: userID, newImageURL: newImageURL)
+        
+        XCTAssertEqual(mockService.updatedUser?.profileImageURL, newImageURL?.absoluteString)
+        XCTAssertEqual(mockService.updatedUser?.name, existingUser.name)
+        XCTAssertEqual(mockService.updatedUser?.description, existingUser.description)
+    }
+    
+    func testDeleteUser() async throws {
+        let userID = "testUserID"
+        
+        try await userUseCase.deleteUser(userID: userID)
+        
+        XCTAssertEqual(mockService.deletedUserID, userID)
+    }
+}
+
+final class MockUserService: UserService {
+    var createdUser: MolioUserDTO?
+    var mockedUser: MolioUserDTO?
+    var updatedUser: MolioUserDTO?
+    var deletedUserID: String?
+    
+    func createUser(_ user: MolioUserDTO) async throws {
+        createdUser = user
+    }
+    
+    func readUser(userID: String) async throws -> MolioUserDTO {
+        guard let mockedUser = mockedUser else {
+            throw NSError(domain: "User not found", code: 404, userInfo: nil)
+        }
+        return mockedUser
+    }
+    
+    func updateUser(_ user: MolioUserDTO) async throws {
+        updatedUser = user
+    }
+    
+    func deleteUser(userID: String) async throws {
+        deletedUserID = userID
+    }
+}


### PR DESCRIPTION
## 1. 배경
- 사용자 관련 비즈니스 로직을 처리하기 위해 UseCase 레이어를 도입.
- UserService를 활용하여 데이터 소스와의 의존성을 분리하고, 클린 아키텍처 원칙을 준수하기 위함.

## 2. 작업 내용
- [x] UserUseCase 프로토콜 정의:
  - [x] 사용자 생성, 조회, 업데이트, 삭제와 관련된 메서드 선언.
- [x] DefaultUserUseCase 구현체 작성:
  - [x] UserService를 활용하여 사용자 관련 비즈니스 로직 처리.
  - [x] MolioUserDTO와 MolioUser 간의 변환 로직 포함.
  - [x] 다음 기능 구현:
    - [x] 사용자 생성 (`createUser`)
    - [x] 사용자 조회 (`fetchUser`)
    - [x] 사용자 이름, 설명, 이미지 업데이트 (`updateUserName`, `updateUserDescription`, `updateUserImage`)
    - [x] 사용자 삭제 (`deleteUser`).
   - [x] 테스트 코드 추가 및 통과
    <img width="375" alt="스크린샷 2024-11-27 오후 6 40 12" src="https://github.com/user-attachments/assets/e21a6297-8818-4d53-bae3-d2ea64ca35b2">

## 3. Issue 번호
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #210
