### PR TITLE
feat: 유저(친구, 나)의 프로필 화면 추가

### DIFF
--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -74,10 +74,14 @@
 		206149442CF87FFA00FDE96D /* UserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149412CF87FFA00FDE96D /* UserUseCase.swift */; };
 		206149462CF8800500FDE96D /* MolioUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149452CF8800500FDE96D /* MolioUser.swift */; };
 		206149482CF8801600FDE96D /* DefaultUserUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149472CF8801600FDE96D /* DefaultUserUseCaseTests.swift */; };
+		2061494A2CF8E31600FDE96D /* UserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149492CF8E31500FDE96D /* UserProfileView.swift */; };
 		2075FEC12CECDDC0009834BE /* CreatePlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC02CECDDC0009834BE /* CreatePlaylistViewModel.swift */; };
 		2075FEC42CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC32CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift */; };
 		2075FEC62CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */; };
 		2075FEC82CECDF4D009834BE /* CoreDataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC72CECDF4D009834BE /* CoreDataError.swift */; };
+		20883BC72CF8EC5B00C10549 /* FollowRelationButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20883BC62CF8EC5B00C10549 /* FollowRelationButton.swift */; };
+		20883BC92CF95F0900C10549 /* FollowRelationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20883BC82CF95F0900C10549 /* FollowRelationType.swift */; };
+		20883BCB2CF9658300C10549 /* UserProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20883BCA2CF9658300C10549 /* UserProfileViewModel.swift */; };
 		20A500692CEF119000E13440 /* SelectPlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A500682CEF119000E13440 /* SelectPlaylistView.swift */; };
 		20A5006B2CEF150F00E13440 /* SelectPlaylistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A5006A2CEF150F00E13440 /* SelectPlaylistViewModel.swift */; };
 		20C655902CEF48C900C60B9C /* FetchAllPlaylistsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C6558F2CEF48C900C60B9C /* FetchAllPlaylistsUseCase.swift */; };
@@ -326,10 +330,14 @@
 		206149412CF87FFA00FDE96D /* UserUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserUseCase.swift; sourceTree = "<group>"; };
 		206149452CF8800500FDE96D /* MolioUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MolioUser.swift; sourceTree = "<group>"; };
 		206149472CF8801600FDE96D /* DefaultUserUseCaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultUserUseCaseTests.swift; sourceTree = "<group>"; };
+		206149492CF8E31500FDE96D /* UserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileView.swift; sourceTree = "<group>"; };
 		2075FEC02CECDDC0009834BE /* CreatePlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePlaylistViewModel.swift; sourceTree = "<group>"; };
 		2075FEC32CECDE29009834BE /* ChangeCurrentPlaylistIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeCurrentPlaylistIUseCase.swift; sourceTree = "<group>"; };
 		2075FEC52CECDE37009834BE /* DefaultChangeCurrentPlaylistIUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChangeCurrentPlaylistIUseCase.swift; sourceTree = "<group>"; };
 		2075FEC72CECDF4D009834BE /* CoreDataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataError.swift; sourceTree = "<group>"; };
+		20883BC62CF8EC5B00C10549 /* FollowRelationButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowRelationButton.swift; sourceTree = "<group>"; };
+		20883BC82CF95F0900C10549 /* FollowRelationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowRelationType.swift; sourceTree = "<group>"; };
+		20883BCA2CF9658300C10549 /* UserProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileViewModel.swift; sourceTree = "<group>"; };
 		20A500682CEF119000E13440 /* SelectPlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectPlaylistView.swift; sourceTree = "<group>"; };
 		20A5006A2CEF150F00E13440 /* SelectPlaylistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectPlaylistViewModel.swift; sourceTree = "<group>"; };
 		20C6558F2CEF48C900C60B9C /* FetchAllPlaylistsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAllPlaylistsUseCase.swift; sourceTree = "<group>"; };
@@ -1399,6 +1407,10 @@
 			isa = PBXGroup;
 			children = (
 				F135BD022CF4C382006C6C4F /* CommunityViewController.swift */,
+				206149492CF8E31500FDE96D /* UserProfileView.swift */,
+				20883BC62CF8EC5B00C10549 /* FollowRelationButton.swift */,
+				20883BC82CF95F0900C10549 /* FollowRelationType.swift */,
+				20883BCA2CF9658300C10549 /* UserProfileViewModel.swift */,
 			);
 			path = Community;
 			sourceTree = "<group>";
@@ -1843,6 +1855,7 @@
 				B867AE632CF7240900ACCEDC /* PlatformSelectionViewController.swift in Sources */,
 				F12054EC2CF802B80040A69C /* SettingViewController.swift in Sources */,
 				F173692D2CDC9CF300F6242C /* UIColor+Extension.swift in Sources */,
+				20883BC92CF95F0900C10549 /* FollowRelationType.swift in Sources */,
 				2003BA162CDB8D69002CAB3E /* Font+Extension.swift in Sources */,
 				F135BD0A2CF5C671006C6C4F /* ProfileItemView.swift in Sources */,
 				F1E405A92CECA2D000533701 /* DefaultSignAppleRepository.swift in Sources */,
@@ -1919,6 +1932,7 @@
 				884529512CF715C6007FD074 /* MolioPlaylistMapper.swift in Sources */,
 				B8046A542CEB93F900933704 /* FetchAvailableGenresUseCase.swift in Sources */,
 				2075FEC12CECDDC0009834BE /* CreatePlaylistViewModel.swift in Sources */,
+				20883BC72CF8EC5B00C10549 /* FollowRelationButton.swift in Sources */,
 				884529462CF6EBC4007FD074 /* PlaylistService.swift in Sources */,
 				F135BD032CF4C382006C6C4F /* CommunityViewController.swift in Sources */,
 				B8046A562CEB943B00933704 /* DefaultFetchAvailableGenresUseCase.swift in Sources */,
@@ -1962,6 +1976,7 @@
 				8816226D2CE3B11C00E81EA0 /* MusicDeck.swift in Sources */,
 				F1E4059B2CEC6E9B00533701 /* LoginViewModel.swift in Sources */,
 				F135BD082CF5A6C4006C6C4F /* SettingView.swift in Sources */,
+				20883BCB2CF9658300C10549 /* UserProfileViewModel.swift in Sources */,
 				201048592CEA2B020015E800 /* CreatePlaylistUseCase.swift in Sources */,
 				881622692CE3671400E81EA0 /* RandomMusicDeck.swift in Sources */,
 				F173695D2CE31CBA00F6242C /* InputOutputViewModel.swift in Sources */,
@@ -1996,6 +2011,7 @@
 				20397E5A2CE5CB3C004ED9CE /* PlaylistRepository.swift in Sources */,
 				200918422CECA79A0058D8C7 /* UserDefaultsError.swift in Sources */,
 				888352EC2CF4D2B500C48F68 /* FirestoreError.swift in Sources */,
+				2061494A2CF8E31600FDE96D /* UserProfileView.swift in Sources */,
 				F17369592CDFB73000F6242C /* RGBAColor.swift in Sources */,
 				B867AE682CF726B300ACCEDC /* DefaultCheckAppleMusicSubscriptionUseCase.swift in Sources */,
 				B8046A3E2CE8780000933704 /* MusicFilterViewController.swift in Sources */,

--- a/Molio/Source/Data/DataSource/Network/FirebaseService/FirebaseFollowRelationService.swift
+++ b/Molio/Source/Data/DataSource/Network/FirebaseService/FirebaseFollowRelationService.swift
@@ -7,7 +7,7 @@ final class FirebaseFollowRelationService: FollowRelationService {
     private let collectionName: String = "followRelations"
     
     init(
-        db: Firestore
+        db: Firestore = Firestore.firestore()
     ) {
         self.db = db
         

--- a/Molio/Source/Data/DataSource/Network/FirebaseService/FirebaseUserService.swift
+++ b/Molio/Source/Data/DataSource/Network/FirebaseService/FirebaseUserService.swift
@@ -7,8 +7,8 @@ final class FirebaseUserService: UserService {
     private let db: Firestore
     private let collectionName: String = "users"
     init(
-        storageManager: FirebaseStorageManager,
-        db: Firestore
+        storageManager: FirebaseStorageManager = FirebaseStorageManager(),
+        db: Firestore = Firestore.firestore()
     ) {
         self.storageManager = storageManager
         self.db = db

--- a/Molio/Source/Domain/Entity/MolioPlaylist.swift
+++ b/Molio/Source/Domain/Entity/MolioPlaylist.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct MolioPlaylist: Identifiable {
+struct MolioPlaylist: Identifiable, Hashable {
     let id: UUID
     let authorID: String?
     let name: String

--- a/Molio/Source/Domain/Entity/MusicFilter.swift
+++ b/Molio/Source/Domain/Entity/MusicFilter.swift
@@ -1,5 +1,5 @@
 /// 음악 추천을 받기 위한 필터
-struct MusicFilter: Decodable {
+struct MusicFilter: Decodable, Hashable {
     /// 선택한 장르 유형들
     var genres: [MusicGenre]
 }

--- a/Molio/Source/Presentation/Community/CommunityViewController.swift
+++ b/Molio/Source/Presentation/Community/CommunityViewController.swift
@@ -8,7 +8,32 @@ final class CommunityViewController: UIViewController {
     }
     
     private func setupUserProfileView() {
-        let userProfileView = UserProfileView(isMyProfile: true)
+        let viewModelForMyProfile = UserProfileViewModel(
+            fetchPlaylistUseCase: DefaultFetchPlaylistUseCase(
+                playlistRepisitory: DefaultPlaylistRepository(
+                    playlistService: FirestorePlaylistService(),
+                    playlistStorage: CoreDataPlaylistStorage()
+                ),
+                musicKitService: DefaultMusicKitService(),
+                currentUserIDUseCase: DefaultCurrentUserIdUseCase(
+                    authService: DefaultFirebaseAuthService(),
+                    usecase: DefaultManageAuthenticationUseCase(
+                        authStateRepository: DefaultAuthStateRepository()
+                    )
+                )
+            ),
+            currentUserIdUseCase: DefaultCurrentUserIdUseCase(
+                authService: DefaultFirebaseAuthService(),
+                usecase: DefaultManageAuthenticationUseCase(
+                    authStateRepository: DefaultAuthStateRepository()
+                )
+            ),
+            followRelationUseCase: DefaultFollowRelationUseCase(
+                service: FirebaseFollowRelationService(),
+                authService: DefaultFirebaseAuthService()
+            ), userUseCase: DefaultUserUseCase(service: FirebaseUserService())
+        )
+        let userProfileView = UserProfileView(isMyProfile: true, viewModel: viewModelForMyProfile)
         
         let hostingController = UIHostingController(rootView: userProfileView)
         

--- a/Molio/Source/Presentation/Community/CommunityViewController.swift
+++ b/Molio/Source/Presentation/Community/CommunityViewController.swift
@@ -1,7 +1,28 @@
+import SwiftUI
 import UIKit
 
 final class CommunityViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupUserProfileView()
+    }
+    
+    private func setupUserProfileView() {
+        let userProfileView = UserProfileView(isMyProfile: true)
+        
+        let hostingController = UIHostingController(rootView: userProfileView)
+        
+        addChild(hostingController)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hostingController.view)
+        
+        NSLayoutConstraint.activate([
+            hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        
+        hostingController.didMove(toParent: self)
     }
 }

--- a/Molio/Source/Presentation/Community/FollowRelationButton.swift
+++ b/Molio/Source/Presentation/Community/FollowRelationButton.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct FollowRelationButton: View {
+    var type: FollowRelationType
+    var action: () -> Void = {}
+    
+    var body: some View {
+        Button(action: action) {
+            Text.molioSemiBold(type.rawValue, size: 13)
+                .foregroundColor(textColor)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(backgroundColor)
+                .cornerRadius(10)
+        }
+    }
+    
+    // 버튼의 배경색을 타입에 따라 변경
+    private var backgroundColor: Color {
+        switch type {
+        case .following:
+            return Color.white.opacity(0.2)
+        case .unfollowing:
+            return Color.mainLighter
+        }
+        
+    }
+    
+    private var textColor: Color {
+        switch type {
+        case .following:
+            return Color.white
+        case .unfollowing:
+            return Color.black
+        }
+    }
+}

--- a/Molio/Source/Presentation/Community/FollowRelationType.swift
+++ b/Molio/Source/Presentation/Community/FollowRelationType.swift
@@ -1,0 +1,5 @@
+enum FollowRelationType: String {
+    case unfollowing = "팔로우"
+    case following = "팔로잉"
+}
+

--- a/Molio/Source/Presentation/Community/UserProfileView.swift
+++ b/Molio/Source/Presentation/Community/UserProfileView.swift
@@ -1,111 +1,116 @@
 import SwiftUI
 
 struct UserProfileView: View {
-    private let playlistCount: Int = 2 // TODO: ViewModel 연결시 삭제
-    private let followingCount: Int = 10 // TODO: ViewModel 연결시 삭제
-    private let followerCount: Int = 20 // TODO: ViewModel 연결시 삭제
-    
+    @StateObject var viewModel: UserProfileViewModel
     let isMyProfile: Bool
     let followRelationType: FollowRelationType?
-    
-    @State var playlistsSample: [MolioPlaylist] = [
-        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
-        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
-        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
-        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
-        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
-        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
-        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
-        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
-        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz]))
-        
-    ]
+    let freindUserID: String?
     
     init(
         isMyProfile: Bool,
-        followRelationType: FollowRelationType? = nil
+        followRelationType: FollowRelationType? = nil,
+        viewModel: UserProfileViewModel,
+        freindUserID: String? = nil
     ) {
         self.isMyProfile = isMyProfile
         self.followRelationType = followRelationType
+        _viewModel = StateObject(wrappedValue: viewModel)
+        self.freindUserID = freindUserID
     }
     
     var body: some View {
-        VStack {
-            // MARK: - 상단 제목 및 기어 버튼
-            HStack {
-                Text("몰리오올리오")
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundColor(.white)
-                Spacer()
-                
-                if isMyProfile {
-                    Button(action: {
-                        print("설정 버튼 클릭")
-                    }) {
-                        Image(systemName: "gearshape.fill")
-                            .foregroundStyle(.main)
-                    }
-                }
-            }
-            .padding(.horizontal, 22)
-            
-            // MARK: - 유저 정보 HStack
-            HStack {
-                Image(systemName: "person.circle")
-                    .resizable()
-                    .frame(width: 82, height: 82)
-                
-                GeometryReader { proxy in
-                    HStack(spacing: 10) {
-                        let size = CGSize(
-                            width: (proxy.size.width - 20) / 3,
-                            height: proxy.size.height
-                        )
-                        userInfoView(type: .playlist, value: playlistCount, size: size)
-                        userInfoView(type: .following, value: followingCount, size: size)
-                        userInfoView(type: .follower, value: followerCount, size: size)
-                    }
-                }
-                .frame(maxWidth: .infinity)
-            }
-            .frame(maxWidth: .infinity, maxHeight: 82)
-            .padding(.horizontal, 22)
-            .padding(.top, 16)
-            
-            Spacer().frame(height: 21)
-            
-            // MARK: - 유저 description
-            Text("몰리 덕후입니다. 플리 공유해요!")
-                .font(.system(size: 14, weight: .regular))
-                .foregroundColor(.white)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 22)
-            
-            Spacer().frame(height: 13)
-            
-            // MARK: - 팔로우 버튼
-            if !isMyProfile, let followRelationType = followRelationType {
-                FollowRelationButton(type: followRelationType)
-                    .padding(.horizontal, 22)
-                    .frame(height: 32)
-            }
-            
-            Spacer().frame(height: 13)
-            
-            // MARK: - 유저 플레이리스트
-            ScrollView(.vertical, showsIndicators: true) {
+        ZStack {
+            if viewModel.isLoading {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                    .scaleEffect(1.5)
+            } else {
                 VStack {
-                    ForEach(playlistsSample, id: \.self) { playlist in
-                        userPlaylistRowView(playlist: playlist)
+                    // MARK: - 상단 제목 및 기어 버튼
+                    HStack {
+                        Text("몰리오올리오")
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundColor(.white)
+                        Spacer()
+                        
+                        if isMyProfile {
+                            Button(action: {
+                                print("설정 버튼 클릭")
+                            }) {
+                                Image(systemName: "gearshape.fill")
+                                    .foregroundStyle(.main)
+                            }
+                        }
                     }
+                    .padding(.horizontal, 22)
+                    
+                    // MARK: - 유저 정보 HStack
+                    HStack {
+                        Image(systemName: "person.circle")
+                            .resizable()
+                            .frame(width: 82, height: 82)
+                        
+                        GeometryReader { proxy in
+                            HStack(spacing: 10) {
+                                let size = CGSize(
+                                    width: (proxy.size.width - 20) / 3,
+                                    height: proxy.size.height
+                                )
+                                userInfoView(type: .playlist, value: viewModel.playlists.count, size: size)
+                                userInfoView(type: .following, value: viewModel.followings.count, size: size)
+                                userInfoView(type: .follower, value: viewModel.followers.count, size: size)
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: 82)
+                    .padding(.horizontal, 22)
+                    .padding(.top, 16)
+                    
+                    Spacer().frame(height: 21)
+                    
+                    // MARK: - 유저 description
+                    
+                    if viewModel.currentID != nil {
+                        Text("몰리 덕후입니다. 플리 공유해요!")
+                            .font(.system(size: 14, weight: .regular))
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 22)
+                    }
+                
+                    Spacer().frame(height: 13)
+                    
+                    // MARK: - 팔로우 버튼
+                    if !isMyProfile, let followRelationType = followRelationType {
+                        FollowRelationButton(type: followRelationType)
+                            .padding(.horizontal, 22)
+                            .frame(height: 32)
+                    }
+                    
+                    Spacer().frame(height: 13)
+                    
+                    // MARK: - 유저 플레이리스트
+                    ScrollView(.vertical, showsIndicators: true) {
+                        VStack {
+                            ForEach(viewModel.playlists, id: \.self) { playlist in
+                                userPlaylistRowView(playlist: playlist)
+                            }
+                        }
+                        .padding(.horizontal, 22)
+                    }
+                    
+                    Spacer()
                 }
-                .padding(.horizontal, 22)
             }
-            
-            Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.background)
+        .onAppear {
+            Task {
+                try await viewModel.fetchData(isMyProfile: isMyProfile, friendUserID: nil)
+            }
+        }
     }
     
     func userPlaylistRowView(playlist: MolioPlaylist) -> some View {
@@ -144,18 +149,5 @@ struct UserProfileView: View {
         case playlist = "플레이리스트"
         case following = "팔로잉"
         case follower = "팔로워"
-    }
-}
-
-#Preview {
-    Group {
-        UserProfileView(isMyProfile: true)
-            .previewDisplayName("내 프로필")
-        
-        UserProfileView(isMyProfile: false, followRelationType: .following)
-            .previewDisplayName("다른 사용자 (팔로우)")
-        
-        UserProfileView(isMyProfile: false, followRelationType: .unfollowing)
-            .previewDisplayName("다른 사용자 (팔로우 안 함)")
     }
 }

--- a/Molio/Source/Presentation/Community/UserProfileView.swift
+++ b/Molio/Source/Presentation/Community/UserProfileView.swift
@@ -1,0 +1,161 @@
+import SwiftUI
+
+struct UserProfileView: View {
+    private let playlistCount: Int = 2 // TODO: ViewModel 연결시 삭제
+    private let followingCount: Int = 10 // TODO: ViewModel 연결시 삭제
+    private let followerCount: Int = 20 // TODO: ViewModel 연결시 삭제
+    
+    let isMyProfile: Bool
+    let followRelationType: FollowRelationType?
+    
+    @State var playlistsSample: [MolioPlaylist] = [
+        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
+        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
+        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
+        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
+        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
+        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
+        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
+        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz])),
+        MolioPlaylist(id: UUID(), name: "카공할 때 듣는 플리", createdAt: Date(), musicISRCs: [], filter: MusicFilter(genres: [.pop, .rock, .jazz]))
+        
+    ]
+    
+    init(
+        isMyProfile: Bool,
+        followRelationType: FollowRelationType? = nil
+    ) {
+        self.isMyProfile = isMyProfile
+        self.followRelationType = followRelationType
+    }
+    
+    var body: some View {
+        VStack {
+            // MARK: - 상단 제목 및 기어 버튼
+            HStack {
+                Text("몰리오올리오")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundColor(.white)
+                Spacer()
+                
+                if isMyProfile {
+                    Button(action: {
+                        print("설정 버튼 클릭")
+                    }) {
+                        Image(systemName: "gearshape.fill")
+                            .foregroundStyle(.main)
+                    }
+                }
+            }
+            .padding(.horizontal, 22)
+            
+            // MARK: - 유저 정보 HStack
+            HStack {
+                Image(systemName: "person.circle")
+                    .resizable()
+                    .frame(width: 82, height: 82)
+                
+                GeometryReader { proxy in
+                    HStack(spacing: 10) {
+                        let size = CGSize(
+                            width: (proxy.size.width - 20) / 3,
+                            height: proxy.size.height
+                        )
+                        userInfoView(type: .playlist, value: playlistCount, size: size)
+                        userInfoView(type: .following, value: followingCount, size: size)
+                        userInfoView(type: .follower, value: followerCount, size: size)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .frame(maxWidth: .infinity, maxHeight: 82)
+            .padding(.horizontal, 22)
+            .padding(.top, 16)
+            
+            Spacer().frame(height: 21)
+            
+            // MARK: - 유저 description
+            Text("몰리 덕후입니다. 플리 공유해요!")
+                .font(.system(size: 14, weight: .regular))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 22)
+            
+            Spacer().frame(height: 13)
+            
+            // MARK: - 팔로우 버튼
+            if !isMyProfile, let followRelationType = followRelationType {
+                FollowRelationButton(type: followRelationType)
+                    .padding(.horizontal, 22)
+                    .frame(height: 32)
+            }
+            
+            Spacer().frame(height: 13)
+            
+            // MARK: - 유저 플레이리스트
+            ScrollView(.vertical, showsIndicators: true) {
+                VStack {
+                    ForEach(playlistsSample, id: \.self) { playlist in
+                        userPlaylistRowView(playlist: playlist)
+                    }
+                }
+                .padding(.horizontal, 22)
+            }
+            
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.background)
+    }
+    
+    func userPlaylistRowView(playlist: MolioPlaylist) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 5) {
+                Text(playlist.name)
+                    .font(.system(size: 16, weight: .regular))
+                    .foregroundColor(.white)
+                HStack {
+                    ForEach(playlist.filter.genres, id: \.self) { genre in
+                        FilterTag(content: genre.description)
+                    }
+                }
+            }
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundColor(.gray)
+        }
+        .frame(height: 70)
+    }
+    
+    func userInfoView(type: UserInfoType, value: Int, size: CGSize) -> some View {
+        VStack {
+            Text(type.rawValue)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.white)
+            Text("\(value)")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.white)
+        }
+        .frame(width: size.width, height: size.height)
+    }
+    
+    enum UserInfoType: String {
+        case playlist = "플레이리스트"
+        case following = "팔로잉"
+        case follower = "팔로워"
+    }
+}
+
+#Preview {
+    Group {
+        UserProfileView(isMyProfile: true)
+            .previewDisplayName("내 프로필")
+        
+        UserProfileView(isMyProfile: false, followRelationType: .following)
+            .previewDisplayName("다른 사용자 (팔로우)")
+        
+        UserProfileView(isMyProfile: false, followRelationType: .unfollowing)
+            .previewDisplayName("다른 사용자 (팔로우 안 함)")
+    }
+}

--- a/Molio/Source/Presentation/Community/UserProfileViewModel.swift
+++ b/Molio/Source/Presentation/Community/UserProfileViewModel.swift
@@ -3,29 +3,86 @@ import SwiftUI
 
 class UserProfileViewModel: ObservableObject {
     @Published var playlists: [MolioPlaylist] = []
+    @Published var followings: [MolioFollowRelation] = []
+    @Published var followers: [MolioFollowRelation] = []
+    @Published var user: MolioUser?
+    @Published var isLoading: Bool = false
+    @Published var currentID: String?
     
     let fetchPlaylistUseCase: FetchPlaylistUseCase
     let currentUserIdUseCase: CurrentUserIdUseCase
     let followRelationUseCase: FollowRelationUseCase
-    
+    let userUseCase: UserUseCase
+
     init(
-         fetchPlaylistUseCase: FetchPlaylistUseCase,
+        fetchPlaylistUseCase: FetchPlaylistUseCase,
         currentUserIdUseCase: CurrentUserIdUseCase,
-         followRelationUseCase: FollowRelationUseCase
+        followRelationUseCase: FollowRelationUseCase,
+        userUseCase: UserUseCase
     ) {
         self.fetchPlaylistUseCase = fetchPlaylistUseCase
         self.currentUserIdUseCase = currentUserIdUseCase
         self.followRelationUseCase = followRelationUseCase
+        self.userUseCase = userUseCase
     }
     
-    func fetchPlaylists(isMyProfile: Bool, friendUserID: String?) async throws {
-        if isMyProfile {
-            playlists = try await fetchPlaylistUseCase.fetchMyAllPlaylists()
-        } else {
-            guard let friendUserID else { return }
-            playlists = try await fetchPlaylistUseCase.fetchFriendAllPlaylists(friendUserID: friendUserID)
+    func fetchData(isMyProfile: Bool, friendUserID: String?) async throws {
+        DispatchQueue.main.async {
+            self.isLoading = true
+        }
+        defer {
+            DispatchQueue.main.async {
+                self.isLoading = false
+            }
+        }
+        
+        guard let currentID = try currentUserIdUseCase.execute() else {
+            let fetchedPlaylists = try await fetchPlaylists(isMyProfile: isMyProfile, friendUserID: friendUserID)
+            DispatchQueue.main.async {
+                self.playlists = fetchedPlaylists
+            }
+            return
+        }
+        
+        let fetchedPlaylists = try await fetchPlaylists(isMyProfile: isMyProfile, friendUserID: friendUserID)
+        let fetchedFollowers = try await fetchFollowers(isMyProfile: isMyProfile, friendUserID: friendUserID)
+        let fetchedFollowings = try await fetchFollowings(isMyProfile: isMyProfile, friendUserID: friendUserID)
+        
+        guard let friendUserID else { return }
+        let fetchedUser = try await userUseCase.fetchUser(userID: isMyProfile ? currentID : friendUserID)
+        
+        DispatchQueue.main.async {
+            self.playlists = fetchedPlaylists
+            self.followers = fetchedFollowers
+            self.followings = fetchedFollowings
+            self.user = fetchedUser
         }
     }
     
-    func
+    private func fetchPlaylists(isMyProfile: Bool, friendUserID: String?) async throws -> [MolioPlaylist] {
+        if isMyProfile {
+            return try await fetchPlaylistUseCase.fetchMyAllPlaylists()
+        } else {
+            guard let friendUserID else { return [] }
+            return try await fetchPlaylistUseCase.fetchFriendAllPlaylists(friendUserID: friendUserID)
+        }
+    }
+    
+    private func fetchFollowers(isMyProfile: Bool, friendUserID: String?) async throws -> [MolioFollowRelation] {
+        if isMyProfile {
+            return try await followRelationUseCase.fetchMyFollowerList()
+        } else {
+            guard let friendUserID else { return [] }
+            return try await followRelationUseCase.fetchFriendFollowerList(userID: friendUserID)
+        }
+    }
+    
+    private func fetchFollowings(isMyProfile: Bool, friendUserID: String?) async throws -> [MolioFollowRelation] {
+        if isMyProfile {
+            return try await followRelationUseCase.fetchMyFollowingList()
+        } else {
+            guard let friendUserID else { return [] }
+            return try await followRelationUseCase.fetchFreindFollowingList(userID: friendUserID)
+        }
+    }
 }

--- a/Molio/Source/Presentation/Community/UserProfileViewModel.swift
+++ b/Molio/Source/Presentation/Community/UserProfileViewModel.swift
@@ -1,0 +1,31 @@
+import Combine
+import SwiftUI
+
+class UserProfileViewModel: ObservableObject {
+    @Published var playlists: [MolioPlaylist] = []
+    
+    let fetchPlaylistUseCase: FetchPlaylistUseCase
+    let currentUserIdUseCase: CurrentUserIdUseCase
+    let followRelationUseCase: FollowRelationUseCase
+    
+    init(
+         fetchPlaylistUseCase: FetchPlaylistUseCase,
+        currentUserIdUseCase: CurrentUserIdUseCase,
+         followRelationUseCase: FollowRelationUseCase
+    ) {
+        self.fetchPlaylistUseCase = fetchPlaylistUseCase
+        self.currentUserIdUseCase = currentUserIdUseCase
+        self.followRelationUseCase = followRelationUseCase
+    }
+    
+    func fetchPlaylists(isMyProfile: Bool, friendUserID: String?) async throws {
+        if isMyProfile {
+            playlists = try await fetchPlaylistUseCase.fetchMyAllPlaylists()
+        } else {
+            guard let friendUserID else { return }
+            playlists = try await fetchPlaylistUseCase.fetchFriendAllPlaylists(friendUserID: friendUserID)
+        }
+    }
+    
+    func
+}


### PR DESCRIPTION
## 1. 배경
- 커뮤니티 기능에서 사용자의 프로필 화면을 보여줘야 합니다.
- 나의 프로필 화면에서는 설정 버튼이 보여야 합니다.
- 친구의 프로필 화면에서는 팔로우 여부에 따라 버튼이 다르게 보여합니다. 또한, 설정 버튼을 보이지 않아야 합니다.
- 하나의 화면으로 여러 모드의 뷰를 보여줄 수 있도록 설계했습니다.
## 2. 작업 내용
- [x] **공용 뷰 설계**:  
  - [x] `UserProfileView`를 하나의 화면에서 `isMyProfile` 플래그와 `followRelationType`을 통해 두 가지 프로필 모드(나의 프로필, 친구의 프로필)를 처리하도록 설계했습니다.
  - [x] **`isMyProfile` 플래그**: 현재 로그인한 사용자의 프로필인지 여부를 판별.
  - [x] **`followRelationType`**: 친구 프로필 모드에서 팔로우 상태를 표시하고, 팔로우/언팔로우 버튼을 제어.

- [x] **뷰모델 로직 추가**:  
  - [x] 데이터를 비동기로 가져오는 동안 로딩 상태를 관리하기 위해 `isLoading` 플래그를 추가.
  - [x] `fetchData` 메서드를 통해 사용자 정보, 팔로워 목록, 팔로잉 목록, 플레이리스트를 병렬로 가져오는 로직 구현.
  - [x] 메인 스레드에서 UI 업데이트를 보장하기 위해 `DispatchQueue.main.async` 사용.

- [x] **기능 개선**:  
  - [x] 기존에 분리되어 있던 UseCase 호출을 하나의 뷰모델 내부에서 통합적으로 관리하도록 개선.
  - [x] 로그인한 사용자와 친구 프로필에 대한 데이터를 각각 처리하기 위해 `fetchPlaylists`, `fetchFollowers`, `fetchFollowings`, `fetchUser` 메서드를 뷰모델에 구현.

- [x] **UI 변경**:  
  - [x] 사용자 정보(playlistCount, followerCount, followingCount)를 `GeometryReader`와 동적으로 배치.
  - [x] 팔로우 버튼은 친구 프로필 화면에서만 나타나도록 조건부로 렌더링.
  - [x] 플레이리스트를 리스트 형식으로 `ScrollView`에 렌더링.

- [x] **Firebase 연동 문제 확인**:  
  - [x] 로그인한 상태에서 데이터 로드가 실패하는 문제를 발견. 이는 인증과 Firestore 데이터베이스 간의 동기화 문제로 추정. 추후 디버깅 예정.

## 3. 스크린샷

|   SE   |   15PRO   | 
| :-------------: |  :-------------: |
| <img width=200 src="https://github.com/user-attachments/assets/261605b6-dc9f-4608-b737-f6dc2b8ce226"> | <img width=200 src="https://github.com/user-attachments/assets/1b969c6c-589e-4446-8afe-37cf1ea690f0"> | 

### 사용예시
![image](https://github.com/user-attachments/assets/37d6d12d-88a2-4f83-b50c-7383f8a962eb)


## 4. Issue 번호
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #203 
Resolved #234 
