### PR TITLE
refactor: 내 프로필 화면에서 내 플레이리스트 목록 보기 기능 로직 수정

### DIFF
--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		206149462CF8800500FDE96D /* MolioUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149452CF8800500FDE96D /* MolioUser.swift */; };
 		206149482CF8801600FDE96D /* DefaultUserUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149472CF8801600FDE96D /* DefaultUserUseCaseTests.swift */; };
 		2061494A2CF8E31600FDE96D /* UserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206149492CF8E31500FDE96D /* UserProfileView.swift */; };
+		206439E62CFC4B5F008E1D42 /* ProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206439E52CFC4B5F008E1D42 /* ProfileImageView.swift */; };
 		2075FEC82CECDF4D009834BE /* CoreDataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2075FEC72CECDF4D009834BE /* CoreDataError.swift */; };
 		2082A09E2CF9B13800E8F2D9 /* UserProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2082A09D2CF9B13800E8F2D9 /* UserProfileViewController.swift */; };
 		2082A0A22CF9C41800E8F2D9 /* FollowRelationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2082A0A12CF9C41800E8F2D9 /* FollowRelationListView.swift */; };
@@ -323,6 +324,7 @@
 		206149452CF8800500FDE96D /* MolioUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MolioUser.swift; sourceTree = "<group>"; };
 		206149472CF8801600FDE96D /* DefaultUserUseCaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultUserUseCaseTests.swift; sourceTree = "<group>"; };
 		206149492CF8E31500FDE96D /* UserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileView.swift; sourceTree = "<group>"; };
+		206439E52CFC4B5F008E1D42 /* ProfileImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageView.swift; sourceTree = "<group>"; };
 		2075FEC72CECDF4D009834BE /* CoreDataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataError.swift; sourceTree = "<group>"; };
 		2082A09D2CF9B13800E8F2D9 /* UserProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileViewController.swift; sourceTree = "<group>"; };
 		2082A0A12CF9C41800E8F2D9 /* FollowRelationListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowRelationListView.swift; sourceTree = "<group>"; };
@@ -1362,6 +1364,7 @@
 				2082A0A02CF9C3EF00E8F2D9 /* FollowRelation */,
 				2082A09F2CF9C3DC00E8F2D9 /* UserProfile */,
 				F135BD022CF4C382006C6C4F /* CommunityViewController.swift */,
+				206439E52CFC4B5F008E1D42 /* ProfileImageView.swift */,
 			);
 			path = Community;
 			sourceTree = "<group>";
@@ -1796,6 +1799,7 @@
 				205E6A442CF563BC005E9150 /* FirebaseStorageManager.swift in Sources */,
 				88E4834B2CEDDD4A003D624E /* MusicListView.swift in Sources */,
 				206149432CF87FFA00FDE96D /* DefaultUserUseCase.swift in Sources */,
+				206439E62CFC4B5F008E1D42 /* ProfileImageView.swift in Sources */,
 				88E4834C2CEDDD4A003D624E /* MusicCellView.swift in Sources */,
 				B867AE632CF7240900ACCEDC /* PlatformSelectionViewController.swift in Sources */,
 				F12054EC2CF802B80040A69C /* SettingViewController.swift in Sources */,

--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -240,7 +240,7 @@
 		F1770B2A2CEE455800C81272 /* ExportPlaylistImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1770B292CEE455800C81272 /* ExportPlaylistImageView.swift */; };
 		F1770B2C2CEEFF2200C81272 /* PlaylistImageMusicItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1770B2B2CEEFF2200C81272 /* PlaylistImageMusicItem.swift */; };
 		F1770B2E2CEF0F4B00C81272 /* PlaylistImagePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1770B2D2CEF0F4B00C81272 /* PlaylistImagePage.swift */; };
-		F17CA42A2CFB638700B86681 /* ProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17CA4292CFB638700B86681 /* ProfileImageView.swift */; };
+		F17CA42A2CFB638700B86681 /* ChangeProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17CA4292CFB638700B86681 /* ChangeProfileImageView.swift */; };
 		F17CA42E2CFC3ADE00B86681 /* ProfileImageUpdateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17CA42D2CFC3ADE00B86681 /* ProfileImageUpdateType.swift */; };
 		F1865ED62CF618B7007C1E5A /* MyInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1865ED52CF618B7007C1E5A /* MyInfoView.swift */; };
 		F1865ED82CF62BBB007C1E5A /* MyInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1865ED72CF62BBB007C1E5A /* MyInfoViewModel.swift */; };
@@ -504,7 +504,7 @@
 		F1770B292CEE455800C81272 /* ExportPlaylistImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportPlaylistImageView.swift; sourceTree = "<group>"; };
 		F1770B2B2CEEFF2200C81272 /* PlaylistImageMusicItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistImageMusicItem.swift; sourceTree = "<group>"; };
 		F1770B2D2CEF0F4B00C81272 /* PlaylistImagePage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistImagePage.swift; sourceTree = "<group>"; };
-		F17CA4292CFB638700B86681 /* ProfileImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageView.swift; sourceTree = "<group>"; };
+		F17CA4292CFB638700B86681 /* ChangeProfileImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeProfileImageView.swift; sourceTree = "<group>"; };
 		F17CA42D2CFC3ADE00B86681 /* ProfileImageUpdateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageUpdateType.swift; sourceTree = "<group>"; };
 		F1865ED52CF618B7007C1E5A /* MyInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoView.swift; sourceTree = "<group>"; };
 		F1865ED72CF62BBB007C1E5A /* MyInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfoViewModel.swift; sourceTree = "<group>"; };
@@ -1343,7 +1343,7 @@
 			children = (
 				F12054ED2CF80B880040A69C /* MyInfoViewController.swift */,
 				F1865ED52CF618B7007C1E5A /* MyInfoView.swift */,
-				F17CA4292CFB638700B86681 /* ProfileImageView.swift */,
+				F17CA4292CFB638700B86681 /* ChangeProfileImageView.swift */,
 				F1865ED92CF63959007C1E5A /* NickNameTextFieldView.swift */,
 				F1865EDB2CF6397B007C1E5A /* DescriptionTextFieldView.swift */,
 			);
@@ -1891,7 +1891,7 @@
 				88A7A9852CF85247005EA318 /* FetchPlaylistUseCaseError.swift in Sources */,
 				206149082CF721F800FDE96D /* DefaultFollowRelationUseCase.swift in Sources */,
 				F17CA42E2CFC3ADE00B86681 /* ProfileImageUpdateType.swift in Sources */,
-				F17CA42A2CFB638700B86681 /* ProfileImageView.swift in Sources */,
+				F17CA42A2CFB638700B86681 /* ChangeProfileImageView.swift in Sources */,
 				2003BA1C2CDB8EE5002CAB3E /* UILabel+Extension.swift in Sources */,
 				F17369682CE36E8F00F6242C /* DefaultImageRepository.swift in Sources */,
 				F1865EDC2CF6397B007C1E5A /* DescriptionTextFieldView.swift in Sources */,

--- a/Molio/Source/App/SceneDelegate.swift
+++ b/Molio/Source/App/SceneDelegate.swift
@@ -36,4 +36,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         appearance.tintColor = .main
         appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
     }
+    
+    func switchToLoginViewController() {
+        let loginViewModel = LoginViewModel()
+        let loginViewController = LoginViewController(viewModel: loginViewModel)
+
+        guard let window = self.window else { return }
+        
+        UIView.transition(with: window, duration: 0.5, options: .transitionCrossDissolve, animations: {
+            window.rootViewController = loginViewController
+        }, completion: nil)
+        
+        window.makeKeyAndVisible()
+    }
 }

--- a/Molio/Source/Domain/UseCase/CurrentUserIdUseCase/DefaultCurrentUserIdUseCase.swift
+++ b/Molio/Source/Domain/UseCase/CurrentUserIdUseCase/DefaultCurrentUserIdUseCase.swift
@@ -14,12 +14,8 @@ struct DefaultCurrentUserIdUseCase: CurrentUserIdUseCase {
         if usecase.isLogin() {
             do {
                 return try authService.getCurrentID()
-            } catch FirebaseAuthError.userNotFound {
-                print("User not logged in. Redirecting to login.")
-            } catch FirebaseAuthError.requiresReauthentication {
-                print("Token expired. Asking user to reauthenticate.")
-            } catch {
-                print("Unhandled error: \(error)")
+            } catch  {
+                print("error.localizedDescription")
             }
         }
         return nil

--- a/Molio/Source/Domain/UseCase/CurrentUserIdUseCase/DefaultCurrentUserIdUseCase.swift
+++ b/Molio/Source/Domain/UseCase/CurrentUserIdUseCase/DefaultCurrentUserIdUseCase.swift
@@ -9,12 +9,19 @@ struct DefaultCurrentUserIdUseCase: CurrentUserIdUseCase {
         self.authService = authService
         self.usecase = usecase
     }
-    
+    // TODO: 로그인 재인증 로직 (로그인 화면으로 이동, 재인증 후 다시 불러오기 등) 처리
     func execute() throws -> String? {
         if usecase.isLogin() {
-            return try authService.getCurrentID()
-        } else {
-            return nil
+            do {
+                return try authService.getCurrentID()
+            } catch FirebaseAuthError.userNotFound {
+                print("User not logged in. Redirecting to login.")
+            } catch FirebaseAuthError.requiresReauthentication {
+                print("Token expired. Asking user to reauthenticate.")
+            } catch {
+                print("Unhandled error: \(error)")
+            }
         }
+        return nil
     }
 }

--- a/Molio/Source/Presentation/Community/FollowRelation/FollowRelationListView.swift
+++ b/Molio/Source/Presentation/Community/FollowRelation/FollowRelationListView.swift
@@ -39,45 +39,7 @@ struct FollowRelationListView: View {
     
     func userIntfoRowView(userName: String, description: String?, imageURL: URL?) -> some View {
         HStack {
-            if let imageURL = imageURL {
-                 AsyncImage(url: imageURL) { phase in
-                     switch phase {
-                     case .empty:
-                         // 로딩 중일 때 표시할 뷰
-                         ProgressView()
-                             .frame(width: 50, height: 50)
-                     case .success(let image):
-                         // 이미지 로드 성공 시
-                         image
-                             .resizable()
-                             .scaledToFill()
-                             .frame(width: 50, height: 50)
-                             .clipShape(Circle())
-                     case .failure(_):
-                         // 로드 실패 시 표시할 뷰
-                         Circle()
-                             .fill(Color.gray)
-                             .frame(width: 50, height: 50)
-                             .overlay(
-                                 Image(systemName: "person.fill")
-                                     .foregroundColor(.white)
-                             )
-                     @unknown default:
-                         // 알 수 없는 상태 처리
-                         EmptyView()
-                     }
-                 }
-             } else {
-                 // URL이 없을 때 기본 뷰
-                 Circle()
-                     .fill(Color.gray)
-                     .frame(width: 50, height: 50)
-                     .overlay(
-                         Image(systemName: "person.fill")
-                             .foregroundColor(.white)
-                     )
-             }
-            
+            ProfileImageView(imageURL: imageURL)
             VStack(alignment: .leading, spacing: 2) {
                 Text.molioMedium(userName, size: 17)
                     .foregroundStyle(.white)

--- a/Molio/Source/Presentation/Community/ProfileImageView.swift
+++ b/Molio/Source/Presentation/Community/ProfileImageView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct ProfileImageView: View {
+    let imageURL: URL?
+    let placeholderIconName: String
+    let size: CGFloat
+
+    init(imageURL: URL?, placeholderIconName: String = "person.fill", size: CGFloat = 50) {
+        self.imageURL = imageURL
+        self.placeholderIconName = placeholderIconName
+        self.size = size
+    }
+
+    var body: some View {
+        if let imageURL = imageURL {
+            AsyncImage(url: imageURL) { phase in
+                switch phase {
+                case .empty:
+                    ProgressView() // 로딩 중
+                        .frame(width: size, height: size)
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: size, height: size)
+                        .clipShape(Circle())
+                case .failure(_):
+                    placeholderView
+                @unknown default:
+                    EmptyView()
+                }
+            }
+        } else {
+            placeholderView
+        }
+    }
+
+    private var placeholderView: some View {
+        Circle()
+            .fill(Color.gray)
+            .frame(width: size, height: size)
+            .overlay(
+                Image(systemName: placeholderIconName)
+                    .foregroundColor(.white)
+            )
+    }
+}

--- a/Molio/Source/Presentation/Community/UserProfile/UserProfileView.swift
+++ b/Molio/Source/Presentation/Community/UserProfile/UserProfileView.swift
@@ -32,7 +32,7 @@ struct UserProfileView: View {
                 VStack {
                     // MARK: - 상단 제목 및 기어 버튼
                     HStack {
-                        Text("몰리오올리오")
+                        Text(viewModel.user?.name ?? "로그인해야 닉네임을 입력할 수 있어요")
                             .font(.system(size: 20, weight: .semibold))
                             .foregroundColor(.white)
                         Spacer()

--- a/Molio/Source/Presentation/Community/UserProfile/UserProfileView.swift
+++ b/Molio/Source/Presentation/Community/UserProfile/UserProfileView.swift
@@ -50,9 +50,7 @@ struct UserProfileView: View {
                     
                     // MARK: - 유저 정보 HStack
                     HStack {
-                        Image(systemName: "person.circle")
-                            .resizable()
-                            .frame(width: 82, height: 82)
+                        ProfileImageView(imageURL: viewModel.user?.profileImageURL)
                         
                         GeometryReader { proxy in
                             HStack(spacing: 10) {
@@ -61,8 +59,7 @@ struct UserProfileView: View {
                                     height: proxy.size.height
                                 )
                                 userInfoView(type: .playlist, value: viewModel.playlists.count, size: size)
-                                
-                                
+                                            
                                 Button(action: {
                                     didFollowingButtonTapped?()
                                 }) {

--- a/Molio/Source/Presentation/Community/UserProfile/UserProfileView.swift
+++ b/Molio/Source/Presentation/Community/UserProfile/UserProfileView.swift
@@ -127,7 +127,7 @@ struct UserProfileView: View {
         .background(Color.background)
         .onAppear {
             Task {
-                try await viewModel.fetchData(isMyProfile: isMyProfile, friendUserID: nil)
+                await viewModel.fetchData(isMyProfile: isMyProfile, friendUserID: nil)
             }
         }
     }

--- a/Molio/Source/Presentation/Community/UserProfile/UserProfileViewModel.swift
+++ b/Molio/Source/Presentation/Community/UserProfile/UserProfileViewModel.swift
@@ -37,7 +37,6 @@ final class UserProfileViewModel: ObservableObject {
                 isMyProfile: isMyProfile,
                 friendUserID: friendUserID
             )
-            print(user ?? "", playlists, followings, followers)
             await updateState(playlists: playlists, followers: followers, followings: followings, user: user)
         } catch {
             print("Error fetching data: \(error.localizedDescription)")

--- a/Molio/Source/Presentation/MyInfo/View/ChangeProfileImageView.swift
+++ b/Molio/Source/Presentation/MyInfo/View/ChangeProfileImageView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct ProfileImageView: View {
+struct ChangeProfileImageView: View {
     let selectedImageData: Data?
     let imageURL: URL?
     

--- a/Molio/Source/Presentation/MyInfo/View/MyInfoView.swift
+++ b/Molio/Source/Presentation/MyInfo/View/MyInfoView.swift
@@ -27,7 +27,7 @@ struct MyInfoView: View {
                 ScrollView {
                     VStack(spacing: 0) {
                         ZStack(alignment: .bottomTrailing) {
-                            ProfileImageView(
+                            ChangeProfileImageView(
                                 selectedImageData: viewModel.userSelectedImageData,
                                 imageURL: viewModel.userImageURL
                             )

--- a/Molio/Source/Presentation/Setting/SettingViewController.swift
+++ b/Molio/Source/Presentation/Setting/SettingViewController.swift
@@ -56,18 +56,9 @@ final class SettingViewController: UIHostingController<SettingView> {
     }
     
     private func switchToLoginViewController() {
-        let loginViewModel = LoginViewModel()
-        let loginViewController = LoginViewController(viewModel: loginViewModel)
-        
-        guard let window = self.view.window else { return }
-        
-        UIView.transition(with: window, duration: 0.5) {
-            loginViewController.view.alpha = 0.0
-            window.rootViewController = loginViewController
-            loginViewController.view.alpha = 1.0
+        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+            sceneDelegate.switchToLoginViewController()
         }
-        
-        window.makeKeyAndVisible()
     }
 }
 


### PR DESCRIPTION
## 1. 배경
- 사용자는 내 프로필을 확인할 때에, 자신의 플레이리스트 목록과 갯수를 확인할 수 있어야 합니다.
- 사용자는 자신의 프로필 (닉네임, 프로필이미지)를 프로필에서 확인할 수 있어야 합니다.

## 2. 작업 내용
- [x] UserProfileViewModel 로직 수정
- [x] UserProfileView - 사용자의 이름, 이미지 표시 


## 3. 스크린샷
 <img width=200 src="https://github.com/user-attachments/assets/8223dc00-01c3-4a8c-bad1-2b9cf25f1ce4">

## 4. Issue 번호
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
#258 
- 팔로우, 팔로잉이 잘보이는지 확인해야 합니다