### PR TITLE
feat: FriendPlaylistDetailView에 UseCase 연결

### DIFF
--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		88291CBC2CFA25F4007322B5 /* SelectPlaylistToExportFriendMusicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88291CBB2CFA25F4007322B5 /* SelectPlaylistToExportFriendMusicView.swift */; };
 		88291CBE2CFA2605007322B5 /* SelectPlaylistToExportFriendMusicViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88291CBD2CFA2605007322B5 /* SelectPlaylistToExportFriendMusicViewModel.swift */; };
 		88291CC32CFB00D2007322B5 /* FriendPlaylistDetailHostingViewController+ExportFriendsMusicToMyPlaylistDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88291CC22CFB00D2007322B5 /* FriendPlaylistDetailHostingViewController+ExportFriendsMusicToMyPlaylistDelegate.swift */; };
+		882D56232CFC6D2C0057D436 /* AudioPlayerControlViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882D56222CFC6D2C0057D436 /* AudioPlayerControlViewModel.swift */; };
 		884529462CF6EBC4007FD074 /* PlaylistService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884529452CF6EBC4007FD074 /* PlaylistService.swift */; };
 		884529482CF6EC6D007FD074 /* FirestorePlaylistService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884529472CF6EC6D007FD074 /* FirestorePlaylistService.swift */; };
 		8845294A2CF6ECDD007FD074 /* MolioPlaylistDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884529492CF6ECDD007FD074 /* MolioPlaylistDTO.swift */; };
@@ -365,6 +366,7 @@
 		88291CBB2CFA25F4007322B5 /* SelectPlaylistToExportFriendMusicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectPlaylistToExportFriendMusicView.swift; sourceTree = "<group>"; };
 		88291CBD2CFA2605007322B5 /* SelectPlaylistToExportFriendMusicViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectPlaylistToExportFriendMusicViewModel.swift; sourceTree = "<group>"; };
 		88291CC22CFB00D2007322B5 /* FriendPlaylistDetailHostingViewController+ExportFriendsMusicToMyPlaylistDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FriendPlaylistDetailHostingViewController+ExportFriendsMusicToMyPlaylistDelegate.swift"; sourceTree = "<group>"; };
+		882D56222CFC6D2C0057D436 /* AudioPlayerControlViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayerControlViewModel.swift; sourceTree = "<group>"; };
 		884529452CF6EBC4007FD074 /* PlaylistService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistService.swift; sourceTree = "<group>"; };
 		884529472CF6EC6D007FD074 /* FirestorePlaylistService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestorePlaylistService.swift; sourceTree = "<group>"; };
 		884529492CF6ECDD007FD074 /* MolioPlaylistDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MolioPlaylistDTO.swift; sourceTree = "<group>"; };
@@ -643,7 +645,6 @@
 				88E483462CEDDD4A003D624E /* PlaylistDetailView.swift */,
 				88E483482CEDDD4A003D624E /* MusicListView.swift */,
 				88E483452CEDDD4A003D624E /* MusicCellView.swift */,
-				88E483472CEDDD4A003D624E /* AudioPlayerControlView.swift */,
 				B81086EA2CF5AEFD00403E88 /* PlaylistDetailViewController.swift */,
 			);
 			path = View;
@@ -818,6 +819,15 @@
 			path = FriendPlaylistDetailView;
 			sourceTree = "<group>";
 		};
+		882D56242CFC6E2B0057D436 /* AudioPlayerControl */ = {
+			isa = PBXGroup;
+			children = (
+				88E483472CEDDD4A003D624E /* AudioPlayerControlView.swift */,
+				882D56222CFC6D2C0057D436 /* AudioPlayerControlViewModel.swift */,
+			);
+			path = AudioPlayerControl;
+			sourceTree = "<group>";
+		};
 		8845294D2CF7128D007FD074 /* PlaylistService */ = {
 			isa = PBXGroup;
 			children = (
@@ -976,6 +986,7 @@
 		B80970762CDB43E2007BC3C4 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				882D56242CFC6E2B0057D436 /* AudioPlayerControl */,
 				B89FFA842CFB8B0B0072F92B /* SearchUser */,
 				F1865ED42CF6188E007C1E5A /* MyInfo */,
 				F135BD062CF5A6AB006C6C4F /* Setting */,
@@ -1935,6 +1946,7 @@
 				2082A0A22CF9C41800E8F2D9 /* FollowRelationListView.swift in Sources */,
 				2082A09E2CF9B13800E8F2D9 /* UserProfileViewController.swift in Sources */,
 				884529512CF715C6007FD074 /* MolioPlaylistMapper.swift in Sources */,
+				882D56232CFC6D2C0057D436 /* AudioPlayerControlViewModel.swift in Sources */,
 				B8046A542CEB93F900933704 /* FetchAvailableGenresUseCase.swift in Sources */,
 				20883BC72CF8EC5B00C10549 /* FollowRelationButton.swift in Sources */,
 				884529462CF6EBC4007FD074 /* PlaylistService.swift in Sources */,

--- a/Molio/Source/Domain/Entity/MolioMusic.swift
+++ b/Molio/Source/Domain/Entity/MolioMusic.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Swipe 할 수 있는 카드 정보에 표시되는 음악 정보에 대한 Entity입니다.
-struct MolioMusic {
+struct MolioMusic: Equatable {
     /// 노래 제목
     let title: String
     
@@ -25,4 +25,10 @@ struct MolioMusic {
     
     /// 앨범에 이미지에 따른 primary 색상
     let primaryTextColor: RGBAColor?
+    
+    // Equatable
+    
+    static func == (lhs: MolioMusic, rhs: MolioMusic) -> Bool {
+        return lhs.isrc == rhs.isrc
+    }
 }

--- a/Molio/Source/Presentation/AudioPlayerControl/AudioPlayerControlView.swift
+++ b/Molio/Source/Presentation/AudioPlayerControl/AudioPlayerControlView.swift
@@ -2,7 +2,7 @@ import AVKit
 import SwiftUI
 
 struct AudioPlayerControlView: View {
-    @EnvironmentObject private var viewModel: PlaylistDetailViewModel
+    @EnvironmentObject private var viewModel: AudioPlayerControlViewModel
     
     var body: some View {
         HStack {

--- a/Molio/Source/Presentation/AudioPlayerControl/AudioPlayerControlViewModel.swift
+++ b/Molio/Source/Presentation/AudioPlayerControl/AudioPlayerControlViewModel.swift
@@ -1,0 +1,134 @@
+import AVKit
+import SwiftUI
+import Combine
+
+final class AudioPlayerControlViewModel: ObservableObject {
+    
+    // MARK: - 기본
+    
+    @Published var musics: [MolioMusic] = []
+    @Published var currentPlayingMusic: MolioMusic?
+    @Published var isPlaying: Bool = false
+        
+    // MARK: - UseCase
+    
+    private var currentPlayingMusicIndex: Int? {
+        get {
+            musics.firstIndex { $0.isrc == currentPlayingMusic?.isrc }
+        } set {
+            // 값이 없거나 새로운 값이 노래 개수를 벗으난 경우에는
+            guard let newValue = newValue else {
+                currentPlayingMusic = nil
+                return
+            }
+            
+            // 새로운 값이 노래 개수를 벗어난 경우에 nil로 설정한다
+            guard (0 ..< musics.count).contains(newValue) else {
+                currentPlayingMusic = nil
+                return
+            }
+            
+            self.currentPlayingMusic = musics[newValue]
+        }
+    }
+    
+    private var subscriptions: Set<AnyCancellable> = []
+    private var audioPlayer: AudioPlayer
+
+    init(
+        audioPlayer: AudioPlayer = DIContainer.shared.resolve()
+    ) {
+        self.audioPlayer = audioPlayer
+        
+        setupAudioPlayer()
+        bind()
+    }
+    
+    // MARK: - Audio Player
+    
+    func setMusics(_ musics: [MolioMusic]) {
+        self.musics = musics
+    }
+    
+    private func bind() {
+        
+        // MARK: - 현재 플레이 중인 노래 AudioPlayer에 바인딩 하기
+    
+        self.$currentPlayingMusic
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] currentPlayingMusic in
+                guard let currentPlayingMusic else {
+                    // 현재 플레잉하는 노래가 nil이 되면 isPlayling이가 false가 된다
+                    self?.isPlaying = false
+                    return
+                }
+                
+                self?.isPlaying = true
+                self?.audioPlayer.loadSong(with: currentPlayingMusic.previewAsset)
+                self?.audioPlayer.play()
+            }
+            .store(in: &subscriptions)
+        
+        self.$isPlaying
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isPlaying in
+                if isPlaying {
+                    self?.audioPlayer.play()
+                } else {
+                    self?.audioPlayer.pause()
+                }
+            }
+            .store(in: &subscriptions)
+    }
+    
+    // MARK: - Audio Player Control
+    
+    private func setupAudioPlayer() {
+        NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime,
+            object: nil,
+            queue: .main
+        ) { [self] _ in
+            self.handlePlaybackCompletion()
+        }
+    }
+    
+    private func handlePlaybackCompletion() {
+        self.nextButtonTapped()
+    }
+    
+    func playButtonTapped() {
+        guard let currentPlayingMusic else {
+            // 현재 선택된 노래가 없는 경우
+            guard let firstMusic = musics.first else { return }
+            
+            self.currentPlayingMusic = firstMusic
+            
+            return
+        }
+        
+        isPlaying.toggle()
+    }
+    
+    func nextButtonTapped() {
+        // 비어있는 경우에는 아무 일도 일어나지 않는다.
+        guard !self.musics.isEmpty else { return }
+        
+        // 선택된 노래가 없는 경우에 아무 일도 일어나지 않는다.
+        guard let currentPlayingMusicIndex = self.currentPlayingMusicIndex else { return }
+        
+        // 선택된 노래가 있는 경우에는 다음 노래로 이동한다.
+        self.currentPlayingMusicIndex = (currentPlayingMusicIndex + 1) % musics.count
+    }
+    
+    func backwardButtonTapped() {
+        // 비어있는 경우에는 아무 일도 일어나지 않는다.
+        guard !self.musics.isEmpty else { return }
+        
+        // 선택된 노래가 없는 경우에 아무 일도 일어나지 않는다.
+        guard let currentPlayingMusicIndex = self.currentPlayingMusicIndex else { return }
+        
+        // 선택된 노래가 있는 경우에는 이전 노래로 이동한다.
+        self.currentPlayingMusicIndex = (currentPlayingMusicIndex - 1 + musics.count) % musics.count
+    }
+}

--- a/Molio/Source/Presentation/FriendPlaylistDetailView/View/FriendPlaylistDetailHostingViewController.swift
+++ b/Molio/Source/Presentation/FriendPlaylistDetailView/View/FriendPlaylistDetailHostingViewController.swift
@@ -11,7 +11,9 @@ final class FriendPlaylistDetailHostingViewController: UIHostingController<Frien
             fetchPlaylistUseCase: fetchPlaylistUseCase
         )
 
-        let rootView = FriendPlaylistDetailView(viewModel: viewModel)
+        let rootView = FriendPlaylistDetailView(
+            viewModel: viewModel
+        )
         
         super.init(rootView: rootView)
         

--- a/Molio/Source/Presentation/FriendPlaylistDetailView/View/FriendPlaylistDetailView.swift
+++ b/Molio/Source/Presentation/FriendPlaylistDetailView/View/FriendPlaylistDetailView.swift
@@ -1,15 +1,18 @@
 import SwiftUI
 
 struct FriendPlaylistDetailView: View {
-    @ObservedObject var viewModel: FriendPlaylistDetailViewModel
+    @ObservedObject var friendPlaylistDetailViewModel: FriendPlaylistDetailViewModel
+    @ObservedObject var audioPlayerViewModel = AudioPlayerControlViewModel()
 
-    init(viewModel: FriendPlaylistDetailViewModel) {
-        self._viewModel = ObservedObject(initialValue: viewModel)
+    init(
+        viewModel: FriendPlaylistDetailViewModel
+    ) {
+        self._friendPlaylistDetailViewModel = ObservedObject(initialValue: viewModel)
     }
     
     var body: some View {
         VStack {
-            Text.molioBold(viewModel.friendPlaylist?.name ?? "제목 없음", size: 34)
+            Text.molioBold(friendPlaylistDetailViewModel.friendPlaylist?.name ?? "제목 없음", size: 34)
                 .foregroundStyle(.white)
                 .padding(.leading)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -17,7 +20,7 @@ struct FriendPlaylistDetailView: View {
             // TODO: - 장르 태그 보여주기
 
             List { 
-                ForEach(viewModel.friendPlaylistMusics, id: \.isrc) { molioMusic in
+                ForEach(friendPlaylistDetailViewModel.friendPlaylistMusics, id: \.isrc) { molioMusic in
                     MusicCellView(music: molioMusic)
                         .foregroundStyle(.white)
                         .backgroundStyle(.clear)
@@ -26,7 +29,7 @@ struct FriendPlaylistDetailView: View {
                         .listRowInsets(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 0))
                         .swipeActions {
                             Button {
-                                viewModel.exportFriendsMusicToMyPlaylist(molioMusic: molioMusic)
+                                friendPlaylistDetailViewModel.exportFriendsMusicToMyPlaylist(molioMusic: molioMusic)
                             } label: {
                                 Image
                                     .molioSemiBold(
@@ -52,11 +55,15 @@ struct FriendPlaylistDetailView: View {
         .safeAreaInset(edge: .bottom) {
             HStack(spacing: 11) {
                 AudioPlayerControlView()
+                    .environmentObject(audioPlayerViewModel)
                     .layoutPriority(1)
             }
             .frame(maxWidth: .infinity, maxHeight: 66)
             .padding(.horizontal, 22)
             .padding(.bottom, 23)
+        }
+        .onChange(of: friendPlaylistDetailViewModel.friendPlaylistMusics) { musics in
+            audioPlayerViewModel.setMusics(musics)
         }
     }
 }

--- a/Molio/Source/Presentation/FriendPlaylistDetailView/View/FriendPlaylistDetailView.swift
+++ b/Molio/Source/Presentation/FriendPlaylistDetailView/View/FriendPlaylistDetailView.swift
@@ -51,10 +51,7 @@ struct FriendPlaylistDetailView: View {
         .background(Color.background)
         .safeAreaInset(edge: .bottom) {
             HStack(spacing: 11) {
-                AudioPlayerControlView(
-                    musics: $viewModel.friendPlaylistMusics,
-                    selectedIndex: $viewModel.selectedIndex
-                )
+                AudioPlayerControlView()
                     .layoutPriority(1)
             }
             .frame(maxWidth: .infinity, maxHeight: 66)

--- a/Molio/Source/Presentation/FriendPlaylistDetailView/View/SelectPlaylistToExportFriendMusicView.swift
+++ b/Molio/Source/Presentation/FriendPlaylistDetailView/View/SelectPlaylistToExportFriendMusicView.swift
@@ -71,11 +71,12 @@ struct SelectPlaylistToExportFriendMusicView: View {
                         
                     }
 
-                    Button("네", role: .destructive) {
+                    Button("네") {
                         let selectedMusic = viewModel.selectedMusic
                         viewModel.exportMusicToMyPlaylist(music: selectedMusic)
                         dismiss()
                     }
+                    
                 } message: {
                     Text("몰리오올리오님의 노래를 내 플레이리스트에 추가할까요?")
                 }

--- a/Molio/Source/Presentation/FriendPlaylistDetailView/ViewModel/FriendPlaylistDetailViewModel.swift
+++ b/Molio/Source/Presentation/FriendPlaylistDetailView/ViewModel/FriendPlaylistDetailViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 
 final class FriendPlaylistDetailViewModel: ObservableObject {
     @Published var friendPlaylist: MolioPlaylist?
@@ -18,7 +19,7 @@ final class FriendPlaylistDetailViewModel: ObservableObject {
     }
     
     private func fetchMusics(for playlist: MolioPlaylist) {
-        Task { [weak self] in
+        Task { @MainActor [weak self] in
             guard let self = self else { return }
             do {
                 // MARK: 친구 아이디가 아닌 경우에도 필요하게 되었다. 임시로 ""로 처리한다. 없어도 된다

--- a/Molio/Source/Presentation/PlaylistDetail/View/AudioPlayerControlView.swift
+++ b/Molio/Source/Presentation/PlaylistDetail/View/AudioPlayerControlView.swift
@@ -2,45 +2,36 @@ import AVKit
 import SwiftUI
 
 struct AudioPlayerControlView: View {
-    @Binding private var musics: [MolioMusic]
-    @Binding private var selectedIndex: Int?
-    @State private var isPlaying: Bool = false
-    private var player: AudioPlayer
-    
-    init(
-        musics: Binding<[MolioMusic]>,
-        selectedIndex: Binding<Int?>,
-        player: AudioPlayer = DIContainer.shared.resolve()
-    ) {
-        self._musics = musics
-        self._selectedIndex = selectedIndex
-        self.player = player
-        setupPlayer()
-    }
+    @EnvironmentObject private var viewModel: PlaylistDetailViewModel
     
     var body: some View {
         HStack {
             Spacer()
             
-            Button(action: {
-                playPrevious()
-            }) {
+            Button {
+                viewModel.backwardButtonTapped()
+            } label: {
                 Image.molioRegular(systemName: "backward.fill", size: 24, color: .main)
             }
             
             Spacer()
             
-            Button(action: {
-                togglePlayPause()
-            }) {
-                Image.molioRegular(systemName: isPlaying ? "pause.fill" : "play.fill", size: 24, color: .main)
+            Button {
+                viewModel.playButtonTapped()
+            } label: {
+                Image
+                    .molioRegular(
+                        systemName: viewModel.isPlaying ? "pause.fill" : "play.fill",
+                        size: 24,
+                        color: .main
+                    )
             }
             
             Spacer()
             
-            Button(action: {
-                playNext()
-            }) {
+            Button {
+                viewModel.nextButtonTapped()
+            } label: {
                 Image.molioRegular(systemName: "forward.fill", size: 24, color: .main)
             }
             
@@ -48,76 +39,5 @@ struct AudioPlayerControlView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(.gray, in: .capsule)
-        .onChange(of: selectedIndex) { index in
-            guard let index = index, musics.indices.contains(index) else { return }
-            play(musics[index])
-        }
-    }
-    
-    private func setupPlayer() {
-        NotificationCenter.default.addObserver(
-            forName: .AVPlayerItemDidPlayToEndTime,
-            object: nil,
-            queue: .main
-        ) { [self] _ in
-            self.handlePlaybackCompletion()
-        }
-    }
-    
-    private func handlePlaybackCompletion() {
-        guard let index = selectedIndex else { return }
-        
-        if index == musics.count - 1 {
-            selectedIndex = nil
-            isPlaying = false
-        } else {
-            selectedIndex = index + 1
-        }
-    }
-    
-    private func play(_ music: MolioMusic) {
-        DispatchQueue.main.async {
-            player.loadSong(with: music.previewAsset)
-            player.play()
-            isPlaying = true
-        }
-    }
-    
-    private func togglePlayPause() {
-        if isPlaying {
-            player.pause()
-            isPlaying = false
-        } else {
-            /// 아무것도 선택하지 않고, 재생 버튼을 누르면 처음부터 시작한다.
-            if selectedIndex == nil {
-                selectedIndex = 0
-            }
-            if let index = selectedIndex, musics.indices.contains(index) {
-                play(musics[index])
-            }
-            isPlaying = true
-        }
-    }
-    
-    private func playNext() {
-        if let index = selectedIndex {
-            /// 마지막 노래에서 다음노래 버튼 누르면 처음으로 돌아간다
-            if (index + 1) == musics.count {
-                selectedIndex = 0
-            } else {
-                selectedIndex = index + 1
-            }
-        }
-    }
-    
-    private func playPrevious() {
-        if let index = selectedIndex {
-            /// 처음에서 이전노래 버튼 누르면 맨 마지막 노래로 돌아간다.
-            if (index - 1) < 0 {
-                selectedIndex = musics.count - 1
-            } else {
-                selectedIndex = index - 1
-            }
-        }
     }
 }

--- a/Molio/Source/Presentation/PlaylistDetail/View/MusicListView.swift
+++ b/Molio/Source/Presentation/PlaylistDetail/View/MusicListView.swift
@@ -1,36 +1,30 @@
 import SwiftUI
 
 struct MusicListView: View {
-    private let musics: [MolioMusic]
-    @Binding private var selectedIndex: Int?
-
+    @EnvironmentObject private var viewModel: PlaylistDetailViewModel
+    
     @State private var isAlertPresenting: Bool = false
     @State private var removeTargetMusic: MolioMusic?
 
-    init(
-        musics: [MolioMusic],
-        selectedIndex: Binding<Int?>
-    ) {
-        self.musics = musics
-        self._selectedIndex = selectedIndex
-    }
-
     var body: some View {
         List {
-            ForEach(musics.indices, id: \.self) { index in
-                let music = musics[index]
-
-                // TODO: - 정확한 색상 반영
-                MusicCellView(music: music)
-                    .listRowBackground(selectedIndex == index ? Color.tag.opacity(0.3) : Color.clear)
+            ForEach(viewModel.currentPlaylistMusics, id: \.isrc) { rowMusic in
+                let listRowBackground = rowMusic.isrc == viewModel.currentSelectedMusic?.isrc
+                    ? Color.tag.opacity(0.3)
+                    : Color.clear
+                
+                MusicCellView(music: rowMusic)
+                    .listRowBackground(listRowBackground)
                     .listRowSeparatorTint(.gray)
                     .listRowInsets(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 0))
                     .onTapGesture {
-                        selectedIndex = index
+                        viewModel.currentSelectedMusic = viewModel.currentSelectedMusic?.isrc == rowMusic.isrc
+                            ? nil
+                            : rowMusic
                     }
                     .swipeActions {
                         Button {
-                            removeTargetMusic = music
+                            removeTargetMusic = rowMusic
                             isAlertPresenting.toggle()
                         } label: {
                             Label("Delete", systemImage: "trash")
@@ -42,7 +36,11 @@ struct MusicListView: View {
         .foregroundStyle(.white)
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
-        .alert("정말 삭제하시겠습니까?", isPresented: $isAlertPresenting, presenting: removeTargetMusic) { music in
+        .alert(
+            "정말 삭제하시겠습니까?",
+            isPresented: $isAlertPresenting,
+            presenting: removeTargetMusic
+        ) { music in
             Button("삭제") {
                 deleteMusic(music: music)
                 removeTargetMusic = nil
@@ -55,18 +53,6 @@ struct MusicListView: View {
     }
 
     private func deleteMusic(music: MolioMusic) {
-        print("Delete \(music.title)")
-    }
-}
-
-#Preview {
-    ZStack {
-        Color.black
-        MusicListView(
-            musics: MolioMusic.all,
-            selectedIndex: .constant(0)
-        )
-        .foregroundStyle(.white)
-        .background(Color.background)
+        viewModel.deleteMusic(music: music)
     }
 }

--- a/Molio/Source/Presentation/PlaylistDetail/View/MusicListView.swift
+++ b/Molio/Source/Presentation/PlaylistDetail/View/MusicListView.swift
@@ -1,15 +1,16 @@
 import SwiftUI
 
 struct MusicListView: View {
-    @EnvironmentObject private var viewModel: PlaylistDetailViewModel
+    @EnvironmentObject private var playlistDetailViewModel: PlaylistDetailViewModel
+    @EnvironmentObject private var audioPlayerViewModel: AudioPlayerControlViewModel
     
     @State private var isAlertPresenting: Bool = false
     @State private var removeTargetMusic: MolioMusic?
 
     var body: some View {
         List {
-            ForEach(viewModel.currentPlaylistMusics, id: \.isrc) { rowMusic in
-                let listRowBackground = rowMusic.isrc == viewModel.currentSelectedMusic?.isrc
+            ForEach(audioPlayerViewModel.musics, id: \.isrc) { rowMusic in
+                let listRowBackground = rowMusic.isrc == audioPlayerViewModel.currentPlayingMusic?.isrc
                     ? Color.tag.opacity(0.3)
                     : Color.clear
                 
@@ -18,7 +19,7 @@ struct MusicListView: View {
                     .listRowSeparatorTint(.gray)
                     .listRowInsets(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 0))
                     .onTapGesture {
-                        viewModel.currentSelectedMusic = viewModel.currentSelectedMusic?.isrc == rowMusic.isrc
+                        audioPlayerViewModel.currentPlayingMusic = audioPlayerViewModel.currentPlayingMusic?.isrc == rowMusic.isrc
                             ? nil
                             : rowMusic
                     }
@@ -53,6 +54,6 @@ struct MusicListView: View {
     }
 
     private func deleteMusic(music: MolioMusic) {
-        viewModel.deleteMusic(music: music)
+        playlistDetailViewModel.deleteMusic(music: music)
     }
 }

--- a/Molio/Source/Presentation/PlaylistDetail/View/PlaylistDetailView.swift
+++ b/Molio/Source/Presentation/PlaylistDetail/View/PlaylistDetailView.swift
@@ -2,13 +2,14 @@ import SwiftUI
 import Combine
 
 struct PlaylistDetailView: View {
-    @ObservedObject private var viewModel: PlaylistDetailViewModel
+    @ObservedObject private var playlistDetailViewModel: PlaylistDetailViewModel
+    @ObservedObject private var audioPlayerViewModel = AudioPlayerControlViewModel()
     
     var didPlaylistButtonTapped: (() -> Void)?
     var didExportButtonTapped: (() -> Void)?
 
-    init(viewModel: PlaylistDetailViewModel) {
-        self.viewModel = viewModel
+    init(playlistDetailViewModel: PlaylistDetailViewModel) {
+        self.playlistDetailViewModel = playlistDetailViewModel
     }
 
     var body: some View {
@@ -19,7 +20,7 @@ struct PlaylistDetailView: View {
                 HStack(spacing: 10) {
                     Text
                         .molioBold(
-                            viewModel.currentPlaylist?.name ?? "제목 없음",
+                            playlistDetailViewModel.currentPlaylist?.name ?? "제목 없음",
                             size: 34
                         )
                     Image
@@ -36,11 +37,13 @@ struct PlaylistDetailView: View {
             // TODO: - 하이라이트 리믹스 & 전체 재생 버튼
 
             MusicListView()
+                .environmentObject(audioPlayerViewModel)
         }
         .background(Color.background)
         .safeAreaInset(edge: .bottom) {
             HStack(spacing: 11) {
                 AudioPlayerControlView()
+                    .environmentObject(audioPlayerViewModel)
                     .layoutPriority(1)
                 
                 Button {
@@ -61,12 +64,14 @@ struct PlaylistDetailView: View {
             .padding(.horizontal, 22)
             .padding(.bottom, 23)
         }
-        .environmentObject(viewModel)
+        .onChange(of: playlistDetailViewModel.currentPlaylistMusics) { musics in
+            audioPlayerViewModel.setMusics(playlistDetailViewModel.currentPlaylistMusics)
+        }
     }
 }
 
 #Preview {
     PlaylistDetailView(
-        viewModel: PlaylistDetailViewModel()
+        playlistDetailViewModel: PlaylistDetailViewModel()
     )
 }

--- a/Molio/Source/Presentation/PlaylistDetail/View/PlaylistDetailView.swift
+++ b/Molio/Source/Presentation/PlaylistDetail/View/PlaylistDetailView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import Combine
 
 struct PlaylistDetailView: View {
-    @State private var selectedIndex: Int?
     @ObservedObject private var viewModel: PlaylistDetailViewModel
     
     var didPlaylistButtonTapped: (() -> Void)?
@@ -18,8 +17,17 @@ struct PlaylistDetailView: View {
                 didPlaylistButtonTapped?()
             } label: {
                 HStack(spacing: 10) {
-                    Text.molioBold(viewModel.currentPlaylist?.name ?? "제목 없음", size: 34)
-                    Image.molioMedium(systemName: "chevron.down", size: 16, color: .white)
+                    Text
+                        .molioBold(
+                            viewModel.currentPlaylist?.name ?? "제목 없음",
+                            size: 34
+                        )
+                    Image
+                        .molioMedium(
+                            systemName: "chevron.down",
+                            size: 16,
+                            color: .white
+                        )
                 }
                 .foregroundStyle(.white)
             }
@@ -27,21 +35,23 @@ struct PlaylistDetailView: View {
             
             // TODO: - 하이라이트 리믹스 & 전체 재생 버튼
 
-            MusicListView(
-                musics: viewModel.currentPlaylistMusics,
-                selectedIndex: $selectedIndex
-            )
+            MusicListView()
         }
         .background(Color.background)
         .safeAreaInset(edge: .bottom) {
             HStack(spacing: 11) {
-                AudioPlayerControlView(musics: $viewModel.currentPlaylistMusics, selectedIndex: $selectedIndex)
+                AudioPlayerControlView()
                     .layoutPriority(1)
                 
                 Button {
                     didExportButtonTapped?()
                 } label: {
-                    Image.molioSemiBold(systemName: "square.and.arrow.up", size: 20, color: .main)
+                    Image
+                        .molioSemiBold(
+                            systemName: "square.and.arrow.up",
+                            size: 20,
+                            color: .main
+                        )
                 }
                 .frame(width: 66, height: 66)
                 .background(Color.gray)
@@ -51,6 +61,7 @@ struct PlaylistDetailView: View {
             .padding(.horizontal, 22)
             .padding(.bottom, 23)
         }
+        .environmentObject(viewModel)
     }
 }
 

--- a/Molio/Source/Presentation/PlaylistDetail/View/PlaylistDetailViewController.swift
+++ b/Molio/Source/Presentation/PlaylistDetail/View/PlaylistDetailViewController.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 
 final class PlaylistDetailViewController: UIHostingController<PlaylistDetailView> {
-    private let viewModel: PlaylistDetailViewModel
+    private let playlistDetailViewModel: PlaylistDetailViewModel
     
     // MARK: - Initializer
     
     init(viewModel: PlaylistDetailViewModel) {
-        self.viewModel = viewModel
-        let playlistDetailView = PlaylistDetailView(viewModel: viewModel)
+        self.playlistDetailViewModel = viewModel
+        let playlistDetailView = PlaylistDetailView(playlistDetailViewModel: viewModel)
         super.init(rootView: playlistDetailView)
         
         rootView.didPlaylistButtonTapped = presentPlaylistChangeSheet
@@ -15,7 +15,7 @@ final class PlaylistDetailViewController: UIHostingController<PlaylistDetailView
     }
 
     required init?(coder aDecoder: NSCoder) {
-        self.viewModel = PlaylistDetailViewModel()
+        self.playlistDetailViewModel = PlaylistDetailViewModel()
         super.init(coder: aDecoder)
     }
     
@@ -45,13 +45,13 @@ final class PlaylistDetailViewController: UIHostingController<PlaylistDetailView
     }
     
     private func presentPlaylistExportSheet() {
-        let platformSelectionVC = PlatformSelectionViewController(viewModel: viewModel)
+        let platformSelectionVC = PlatformSelectionViewController(viewModel: playlistDetailViewModel)
         platformSelectionVC.delegate = self
         self.presentCustomSheet(platformSelectionVC)
     }
     
     private func presentExportAppleMusicPlaylistView() {
-        let exportAppleMusicPlaylistVC = ExportAppleMusicPlaylistViewController(viewModel: viewModel)
+        let exportAppleMusicPlaylistVC = ExportAppleMusicPlaylistViewController(viewModel: playlistDetailViewModel)
         self.presentCustomSheet(exportAppleMusicPlaylistVC, isOverFullScreen: true)
     }
     
@@ -71,7 +71,7 @@ extension PlaylistDetailViewController: PlatformSelectionViewControllerDelegate 
             case .appleMusic:
                 self?.presentExportAppleMusicPlaylistView()
             case .image:
-                guard let musics = self?.viewModel.currentPlaylistMusics else { return }
+                guard let musics = self?.playlistDetailViewModel.currentPlaylistMusics else { return }
                 self?.presentExportPlaylistImageView(with: musics)
             }
         }

--- a/Molio/Source/Presentation/PlaylistDetail/ViewModel/PlaylistDetailViewModel.swift
+++ b/Molio/Source/Presentation/PlaylistDetail/ViewModel/PlaylistDetailViewModel.swift
@@ -9,11 +9,6 @@ final class PlaylistDetailViewModel: ObservableObject {
     @Published var currentPlaylistMusics: [MolioMusic] = []
     
     @Published private(set) var isAppleMusicSubscriber: Bool = false
-
-    // MARK: - 오디오 플레이어
-    
-    @Published var currentSelectedMusic: MolioMusic?
-    @Published var isPlaying: Bool = false
     
     // MARK: - 내보내기
     
@@ -26,43 +21,19 @@ final class PlaylistDetailViewModel: ObservableObject {
     private let appleMusicUseCase: AppleMusicUseCase
     private let fetchPlaylistUseCase: FetchPlaylistUseCase
     
-    private var currentPlayingMusicIndex: Int? {
-        get {
-            currentPlaylistMusics.firstIndex { $0.isrc == currentSelectedMusic?.isrc }
-        } set {
-            // 값이 없거나 새로운 값이 노래 개수를 벗으난 경우에는
-            guard let newValue = newValue else {
-                currentSelectedMusic = nil
-                return
-            }
-            
-            // 새로운 값이 노래 개수를 벗어난 경우에 nil로 설정한다
-            guard (0 ..< currentPlaylistMusics.count).contains(newValue) else {
-                currentSelectedMusic = nil
-                return
-            }
-            
-            self.currentSelectedMusic = currentPlaylistMusics[newValue]
-        }
-    }
-    
     // MARK: - 컴바인
     
     private var subscriptions: Set<AnyCancellable> = []
-    private var audioPlayer: AudioPlayer
     
     init(
         managePlaylistUseCase: ManageMyPlaylistUseCase = DefaultManageMyPlaylistUseCase(),
-        appleMusicUseCase: any AppleMusicUseCase = DIContainer.shared.resolve(),
-        fetchPlaylistUseCase: any FetchPlaylistUseCase = DIContainer.shared.resolve(),
-        audioPlayer: AudioPlayer = DIContainer.shared.resolve()
+        appleMusicUseCase: AppleMusicUseCase = DIContainer.shared.resolve(),
+        fetchPlaylistUseCase: FetchPlaylistUseCase = DIContainer.shared.resolve()
     ) {
         self.managePlaylistUseCase = managePlaylistUseCase
         self.appleMusicUseCase = appleMusicUseCase
         self.fetchPlaylistUseCase = fetchPlaylistUseCase
-        self.audioPlayer = audioPlayer
         
-        setupAudioPlayer()
         bind()
     }
     
@@ -72,7 +43,8 @@ final class PlaylistDetailViewModel: ObservableObject {
         
         // MARK: - 현재 위치한 플레이리스트 받아오기
         
-        managePlaylistUseCase.currentPlaylistPublisher()
+        managePlaylistUseCase
+            .currentPlaylistPublisher()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] playlist in
                 guard let playlist = playlist else { return }
@@ -85,95 +57,7 @@ final class PlaylistDetailViewModel: ObservableObject {
                 }
             }
             .store(in: &subscriptions)
-        
-        // MARK: - 현재 플레이 중인 노래 AudioPlayer에 바인딩 하기
-    
-        self.$currentSelectedMusic
-            .sink { [weak self] currentPlayingMusic in
-                guard let currentPlayingMusic else {
-                    // 현재 플레잉하는 노래가 nil이 되면 isPlayling이가 false가 된다
-                    self?.isPlaying = false
-                    return
-                }
-                
-                if self?.isPlaying == true {
-                    self?.audioPlayer.stop()
-                } else {
-                    // 없을때 누르면 시작한다.
-                    self?.isPlaying = true
-                    self?.audioPlayer.loadSong(with: currentPlayingMusic.previewAsset)
-                    self?.audioPlayer.play()
-                }
-                
-                self?.audioPlayer.loadSong(with: currentPlayingMusic.previewAsset)
-                self?.audioPlayer.play()
-            }
-            .store(in: &subscriptions)
-        
-        self.$isPlaying
-            .sink { [weak self] isPlaying in
-                if isPlaying {
-                    self?.audioPlayer.play()
-                } else {
-                    self?.audioPlayer.pause()
-                }
-            }
-            .store(in: &subscriptions)
     }
-    
-    // MARK: - Audio Player Control
-    
-    private func setupAudioPlayer() {
-        NotificationCenter.default.addObserver(
-            forName: .AVPlayerItemDidPlayToEndTime,
-            object: nil,
-            queue: .main
-        ) { [self] _ in
-            self.handlePlaybackCompletion()
-        }
-    }
-    
-    private func handlePlaybackCompletion() {
-        self.nextButtonTapped()
-    }
-    
-    func playButtonTapped() {
-        guard let currentPlayingMusic = currentSelectedMusic else {
-            // 현재 선택된 노래가 없는 경우
-            guard let firstMusic = currentPlaylistMusics.first else { return }
-            
-            self.currentSelectedMusic = firstMusic
-            
-            return
-        }
-        
-        isPlaying.toggle()
-    }
-    
-    func nextButtonTapped() {
-        // 비어있는 경우에는 아무 일도 일어나지 않는다.
-        guard !self.currentPlaylistMusics.isEmpty else { return }
-        
-        // 선택된 노래가 없는 경우에 아무 일도 일어나지 않는다.
-        guard let currentPlayingMusicIndex = self.currentPlayingMusicIndex else { return }
-        
-        // 선택된 노래가 있는 경우에는 다음 노래로 이동한다.
-        self.currentPlayingMusicIndex = (currentPlayingMusicIndex + 1) % currentPlaylistMusics.count
-    }
-    
-    func backwardButtonTapped() {
-        // 비어있는 경우에는 아무 일도 일어나지 않는다.
-        guard !self.currentPlaylistMusics.isEmpty else { return }
-        
-        // 선택된 노래가 없는 경우에 아무 일도 일어나지 않는다.
-        guard let currentPlayingMusicIndex = self.currentPlayingMusicIndex else { return }
-        
-        // 선택된 노래가 있는 경우에는 이전 노래로 이동한다.
-        self.currentPlayingMusicIndex = (currentPlayingMusicIndex - 1 + currentPlaylistMusics.count) % currentPlaylistMusics.count
-    }
-    
-    // MARK: - Audio Player 끝
-    
     
     func checkAppleMusicSubscription() {
         Task { @MainActor [weak self] in

--- a/Molio/Source/Presentation/PlaylistDetail/ViewModel/PlaylistDetailViewModel.swift
+++ b/Molio/Source/Presentation/PlaylistDetail/ViewModel/PlaylistDetailViewModel.swift
@@ -20,15 +20,12 @@ final class PlaylistDetailViewModel: ObservableObject {
     @Published var exportStatus: ExportStatus = .preparing
     @Published var createdPlaylistURL: String?
     
-
-    
     // MARK: - UseCase
     
     private let managePlaylistUseCase: ManageMyPlaylistUseCase
     private let appleMusicUseCase: AppleMusicUseCase
     private let fetchPlaylistUseCase: FetchPlaylistUseCase
     
-
     private var currentPlayingMusicIndex: Int? {
         get {
             currentPlaylistMusics.firstIndex { $0.isrc == currentSelectedMusic?.isrc }
@@ -71,7 +68,6 @@ final class PlaylistDetailViewModel: ObservableObject {
     
     // MARK: - Audio Player
     
-
     private func bind() {
         
         // MARK: - 현재 위치한 플레이리스트 받아오기

--- a/Molio/Source/Presentation/PlaylistDetail/ViewModel/PlaylistDetailViewModel.swift
+++ b/Molio/Source/Presentation/PlaylistDetail/ViewModel/PlaylistDetailViewModel.swift
@@ -2,56 +2,182 @@ import Combine
 import SwiftUI
 
 final class PlaylistDetailViewModel: ObservableObject {
-    enum ExportStatus {
-        case preparing
-        case inProgress
-        case finished
-        
-        var displayText: String {
-            switch self {
-            case .preparing: "플레이리스트 내보내기 준비 중..."
-            case .inProgress: "플레이리스트 생성 중..."
-            case .finished: "플레이리스트 생성 완료!"
-            }
-        }
-    }
+    
+    // MARK: - 기본
+    
+    @Published var currentPlaylist: MolioPlaylist?
+    @Published var currentPlaylistMusics: [MolioMusic] = []
+    
+    @Published private(set) var isAppleMusicSubscriber: Bool = false
+
+    // MARK: - 오디오 플레이어
+    
+    @Published var currentSelectedMusic: MolioMusic?
+    @Published var isPlaying: Bool = false
+    
+    // MARK: - 내보내기
+    
+    @Published var exportStatus: ExportStatus = .preparing
+    @Published var createdPlaylistURL: String?
+    
+
+    
+    // MARK: - UseCase
+    
     private let managePlaylistUseCase: ManageMyPlaylistUseCase
     private let appleMusicUseCase: AppleMusicUseCase
     private let fetchPlaylistUseCase: FetchPlaylistUseCase
     
-    @Published private(set) var isAppleMusicSubscriber: Bool = false
-    @Published var currentPlaylist: MolioPlaylist?
-    @Published var currentPlaylistMusics: [MolioMusic] = []
-    @Published var exportStatus: ExportStatus = .preparing
-    @Published var createdPlaylistURL: String?
+
+    private var currentPlayingMusicIndex: Int? {
+        get {
+            currentPlaylistMusics.firstIndex { $0.isrc == currentSelectedMusic?.isrc }
+        } set {
+            // 값이 없거나 새로운 값이 노래 개수를 벗으난 경우에는
+            guard let newValue = newValue else {
+                currentSelectedMusic = nil
+                return
+            }
+            
+            // 새로운 값이 노래 개수를 벗어난 경우에 nil로 설정한다
+            guard (0 ..< currentPlaylistMusics.count).contains(newValue) else {
+                currentSelectedMusic = nil
+                return
+            }
+            
+            self.currentSelectedMusic = currentPlaylistMusics[newValue]
+        }
+    }
+    
+    // MARK: - 컴바인
     
     private var subscriptions: Set<AnyCancellable> = []
+    private var audioPlayer: AudioPlayer
     
     init(
         managePlaylistUseCase: ManageMyPlaylistUseCase = DefaultManageMyPlaylistUseCase(),
         appleMusicUseCase: any AppleMusicUseCase = DIContainer.shared.resolve(),
-        fetchPlaylistUseCase: any FetchPlaylistUseCase = DIContainer.shared.resolve()
+        fetchPlaylistUseCase: any FetchPlaylistUseCase = DIContainer.shared.resolve(),
+        audioPlayer: AudioPlayer = DIContainer.shared.resolve()
     ) {
         self.managePlaylistUseCase = managePlaylistUseCase
         self.appleMusicUseCase = appleMusicUseCase
         self.fetchPlaylistUseCase = fetchPlaylistUseCase
+        self.audioPlayer = audioPlayer
         
+        setupAudioPlayer()
         bind()
     }
+    
+    // MARK: - Audio Player
+    
 
     private func bind() {
+        
+        // MARK: - 현재 위치한 플레이리스트 받아오기
+        
         managePlaylistUseCase.currentPlaylistPublisher()
             .receive(on: DispatchQueue.main)
-            .sink { playlist in
+            .sink { [weak self] playlist in
                 guard let playlist = playlist else { return }
-                self.currentPlaylist = playlist
+                
+                self?.currentPlaylist = playlist
+                
                 Task { @MainActor [weak self] in
                     let playlistMusics = try await self?.fetchPlaylistUseCase.fetchAllMyMusicIn(playlistID: playlist.id)
                     self?.currentPlaylistMusics = playlistMusics ?? []
                 }
             }
             .store(in: &subscriptions)
+        
+        // MARK: - 현재 플레이 중인 노래 AudioPlayer에 바인딩 하기
+    
+        self.$currentSelectedMusic
+            .sink { [weak self] currentPlayingMusic in
+                guard let currentPlayingMusic else {
+                    // 현재 플레잉하는 노래가 nil이 되면 isPlayling이가 false가 된다
+                    self?.isPlaying = false
+                    return
+                }
+                
+                if self?.isPlaying == true {
+                    self?.audioPlayer.stop()
+                } else {
+                    // 없을때 누르면 시작한다.
+                    self?.isPlaying = true
+                    self?.audioPlayer.loadSong(with: currentPlayingMusic.previewAsset)
+                    self?.audioPlayer.play()
+                }
+                
+                self?.audioPlayer.loadSong(with: currentPlayingMusic.previewAsset)
+                self?.audioPlayer.play()
+            }
+            .store(in: &subscriptions)
+        
+        self.$isPlaying
+            .sink { [weak self] isPlaying in
+                if isPlaying {
+                    self?.audioPlayer.play()
+                } else {
+                    self?.audioPlayer.pause()
+                }
+            }
+            .store(in: &subscriptions)
     }
+    
+    // MARK: - Audio Player Control
+    
+    private func setupAudioPlayer() {
+        NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime,
+            object: nil,
+            queue: .main
+        ) { [self] _ in
+            self.handlePlaybackCompletion()
+        }
+    }
+    
+    private func handlePlaybackCompletion() {
+        self.nextButtonTapped()
+    }
+    
+    func playButtonTapped() {
+        guard let currentPlayingMusic = currentSelectedMusic else {
+            // 현재 선택된 노래가 없는 경우
+            guard let firstMusic = currentPlaylistMusics.first else { return }
+            
+            self.currentSelectedMusic = firstMusic
+            
+            return
+        }
+        
+        isPlaying.toggle()
+    }
+    
+    func nextButtonTapped() {
+        // 비어있는 경우에는 아무 일도 일어나지 않는다.
+        guard !self.currentPlaylistMusics.isEmpty else { return }
+        
+        // 선택된 노래가 없는 경우에 아무 일도 일어나지 않는다.
+        guard let currentPlayingMusicIndex = self.currentPlayingMusicIndex else { return }
+        
+        // 선택된 노래가 있는 경우에는 다음 노래로 이동한다.
+        self.currentPlayingMusicIndex = (currentPlayingMusicIndex + 1) % currentPlaylistMusics.count
+    }
+    
+    func backwardButtonTapped() {
+        // 비어있는 경우에는 아무 일도 일어나지 않는다.
+        guard !self.currentPlaylistMusics.isEmpty else { return }
+        
+        // 선택된 노래가 없는 경우에 아무 일도 일어나지 않는다.
+        guard let currentPlayingMusicIndex = self.currentPlayingMusicIndex else { return }
+        
+        // 선택된 노래가 있는 경우에는 이전 노래로 이동한다.
+        self.currentPlayingMusicIndex = (currentPlayingMusicIndex - 1 + currentPlaylistMusics.count) % currentPlaylistMusics.count
+    }
+    
+    // MARK: - Audio Player 끝
+    
     
     func checkAppleMusicSubscription() {
         Task { @MainActor [weak self] in
@@ -81,6 +207,38 @@ final class PlaylistDetailViewModel: ObservableObject {
         }
         Task { @MainActor in
             await UIApplication.shared.open(url)
+        }
+    }
+    
+    func deleteMusic(music: MolioMusic) {
+        guard let currentPlaylistID = currentPlaylist?.id else { return }
+        
+        Task { [weak self] in
+            do {
+                try await self?.managePlaylistUseCase.deleteMusic(musicISRC: music.isrc, from: currentPlaylistID)
+            } catch {
+                debugPrint("노래 삭제 실패: \(error.localizedDescription)")
+            }
+            
+            do {
+                self?.currentPlaylistMusics = try await self?.fetchPlaylistUseCase.fetchAllMyMusicIn(playlistID: currentPlaylistID) ?? []
+            } catch {
+                debugPrint("노래 목록 가져오기 실패: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    enum ExportStatus {
+        case preparing
+        case inProgress
+        case finished
+        
+        var displayText: String {
+            switch self {
+            case .preparing: "플레이리스트 내보내기 준비 중..."
+            case .inProgress: "플레이리스트 생성 중..."
+            case .finished: "플레이리스트 생성 완료!"
+            }
         }
     }
 }


### PR DESCRIPTION
# 배경
PlaylistDetailView 에 유즈케이스가 연결되어 있지 않은 상황이었습니다.
임시로 구현되어 있던 부분 (AudioPlayer 등 여럿)을 수정했습니다.

# 수정내용

## 뷰 컴포넌트 리팩토링

- **`FriendPlaylistDetailView.swift`**
  - `AudioPlayerControlView`에서 `musics`와 `selectedIndex` 바인딩을 제거하고, 초기화를 단순화하였습니다.

- **`AudioPlayerControlView.swift`**
  - 기존의 바인딩을 제거하고 `EnvironmentObject`로 `PlaylistDetailViewModel`을 주입받도록 변경하였습니다.
  - 플레이어 제어 로직을 `PlaylistDetailViewModel`로 이전하여 뷰의 책임을 줄였습니다.

- **`MusicListView.swift`**
  - 바인딩을 제거하고 `EnvironmentObject`로 `PlaylistDetailViewModel`을 주입받도록 수정하였습니다.
  - 음악 선택 관련 로직을 뷰 모델로 이전하여 뷰의 복잡성을 줄였습니다.

## 뷰 모델 개선

- **`PlaylistDetailViewModel.swift`**
  - 오디오 플레이어 관리와 음악 선택을 위한 새로운 속성과 메소드를 추가하였습니다.
  - 재생, 일시정지, 다음 곡, 이전 곡 등의 제어 기능을 포함하여 현재 재생 중인 음악을 업데이트하는 로직을 구현하였습니다.

## PlaylistDetailView 업데이트

- **`PlaylistDetailView.swift`**
  - `selectedIndex` 상태를 제거하고, `PlaylistDetailViewModel`을 `EnvironmentObject`로 주입받도록 수정하였습니다.
  - `MusicListView`와 `AudioPlayerControlView`의 초기화를 단순화하여 코드의 가독성을 높였습니다.

# 스크린샷
### 친구 플리에서 노래를 내 플리로 가져오는 기능
<img src="https://github.com/user-attachments/assets/4fbb52e8-4957-466e-8997-7c704d9bb3d2" alt="ScreenRecording_12-01-2024 19-59-35_1" width="250">

# 관련 이슈
Resolved(#256)