### PR TITLE
refactor: 카드 스와이프 시작 위치 수정

### DIFF
--- a/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
+++ b/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
@@ -1,5 +1,5 @@
-import UIKit
 import Combine
+import UIKit
 
 final class SwipeMusicViewController: UIViewController {
     private let viewModel: SwipeMusicViewModel
@@ -278,7 +278,10 @@ final class SwipeMusicViewController: UIViewController {
         guard let card = gesture.view else { return }
         
         let translation = gesture.translation(in: view)
-        card.center = CGPoint(x: view.center.x + translation.x, y: view.center.y + translation.y)
+        card.center = CGPoint(
+            x: nextCardView.center.x + translation.x,
+            y: nextCardView.center.y + translation.y
+        )
         
         if gesture.state == .changed {
             musicCardDidChangeSwipePublisher.send(translation.x)


### PR DESCRIPTION
## 1. 이슈 내용
노래 카드 스와이프 시작시, 순간적으로 View의 중앙에서 시작하는 위치를 수정했습니다.

## 2. TODO
- [x] 음악 노래 카드 드래그 시 시작 위치 수정

### 3. Issue 번호

<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #283 