### PR TITLE
feat: 플레이리스트가 하나도 없을시 기본 플레이리스트를 생성한다.

### DIFF
--- a/Molio.xcodeproj/project.pbxproj
+++ b/Molio.xcodeproj/project.pbxproj
@@ -209,7 +209,7 @@
 		F135BCF02CF441B7006C6C4F /* DefaultAuthStateRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F135BCEF2CF441B7006C6C4F /* DefaultAuthStateRepository.swift */; };
 		F135BCF42CF445D7006C6C4F /* DefaultAuthLocalStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F135BCF32CF445D7006C6C4F /* DefaultAuthLocalStorage.swift */; };
 		F135BCF82CF45E39006C6C4F /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F135BCF72CF45E39006C6C4F /* SplashViewController.swift */; };
-		F135BCFB2CF4620C006C6C4F /* SplahViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F135BCFA2CF4620C006C6C4F /* SplahViewModel.swift */; };
+		F135BCFB2CF4620C006C6C4F /* SplashViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F135BCFA2CF4620C006C6C4F /* SplashViewModel.swift */; };
 		F135BCFE2CF4BDE3006C6C4F /* MolioTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F135BCFD2CF4BDE3006C6C4F /* MolioTabBarController.swift */; };
 		F135BD032CF4C382006C6C4F /* CommunityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F135BD022CF4C382006C6C4F /* CommunityViewController.swift */; };
 		F135BD082CF5A6C4006C6C4F /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F135BD072CF5A6C4006C6C4F /* SettingView.swift */; };
@@ -479,7 +479,7 @@
 		F135BCEF2CF441B7006C6C4F /* DefaultAuthStateRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAuthStateRepository.swift; sourceTree = "<group>"; };
 		F135BCF32CF445D7006C6C4F /* DefaultAuthLocalStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAuthLocalStorage.swift; sourceTree = "<group>"; };
 		F135BCF72CF45E39006C6C4F /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
-		F135BCFA2CF4620C006C6C4F /* SplahViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplahViewModel.swift; sourceTree = "<group>"; };
+		F135BCFA2CF4620C006C6C4F /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
 		F135BCFD2CF4BDE3006C6C4F /* MolioTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MolioTabBarController.swift; sourceTree = "<group>"; };
 		F135BD022CF4C382006C6C4F /* CommunityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityViewController.swift; sourceTree = "<group>"; };
 		F135BD072CF5A6C4006C6C4F /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
@@ -1548,7 +1548,7 @@
 		F135BCF92CF461F8006C6C4F /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
-				F135BCFA2CF4620C006C6C4F /* SplahViewModel.swift */,
+				F135BCFA2CF4620C006C6C4F /* SplashViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1994,7 +1994,7 @@
 				F17369492CDF250200F6242C /* DefaultFetchRecommendedMusicUseCase.swift in Sources */,
 				B8D554842CE0F3F3007CCD6D /* SpotifyAccessTokenResponseDTO.swift in Sources */,
 				B867AE782CFAF1E000ACCEDC /* DefaultAppleMusicUseCase.swift in Sources */,
-				F135BCFB2CF4620C006C6C4F /* SplahViewModel.swift in Sources */,
+				F135BCFB2CF4620C006C6C4F /* SplashViewModel.swift in Sources */,
 				F173697B2CE4AAC600F6242C /* AudioPlayer.swift in Sources */,
 				F1E4058C2CEB8FC500533701 /* LoginViewController.swift in Sources */,
 				88A7A9832CF84D48005EA318 /* FetchPlaylistUseCase.swift in Sources */,

--- a/Molio/Source/App/SceneDelegate.swift
+++ b/Molio/Source/App/SceneDelegate.swift
@@ -10,7 +10,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         configureAudioSession()
         setupNavigationBarAppearance()
-        let splashViewController = SplashViewController(viewModel: SplahViewModel())
+        let splashViewController = SplashViewController(viewModel: SplashViewModel())
         
         window = UIWindow(windowScene: windowScene)
         window?.rootViewController = UINavigationController(rootViewController: splashViewController)

--- a/Molio/Source/Presentation/MusicFilter/ViewModel/MusicFilterViewModel.swift
+++ b/Molio/Source/Presentation/MusicFilter/ViewModel/MusicFilterViewModel.swift
@@ -13,7 +13,7 @@ final class MusicFilterViewModel: ObservableObject {
     
     init(
         fetchAvailableGenresUseCase: FetchAvailableGenresUseCase = DIContainer.shared.resolve(),
-        managePlaylistUseCase: ManageMyPlaylistUseCase = DefaultManageMyPlaylistUseCase(),
+        managePlaylistUseCase: ManageMyPlaylistUseCase = DIContainer.shared.resolve(),
         allGenres: [MusicGenre] = MusicGenre.allCases,
         selectedGenres: Set<MusicGenre> = []
     ) {

--- a/Molio/Source/Presentation/Splash/View/SplashViewController.swift
+++ b/Molio/Source/Presentation/Splash/View/SplashViewController.swift
@@ -2,9 +2,9 @@ import Combine
 import UIKit
 
 final class SplashViewController: UIViewController {
-    private let viewModel: SplahViewModel
-    private var input: SplahViewModel.Input
-    private var output: SplahViewModel.Output
+    private let viewModel: SplashViewModel
+    private var input: SplashViewModel.Input
+    private var output: SplashViewModel.Output
     
     private let viewDidLoadPublisher = PassthroughSubject<Void, Never>()
     private var cancellables = Set<AnyCancellable>()
@@ -35,9 +35,9 @@ final class SplashViewController: UIViewController {
         return label
     }()
     
-    init(viewModel: SplahViewModel) {
+    init(viewModel: SplashViewModel) {
         self.viewModel = viewModel
-        self.input = SplahViewModel.Input(viewDidLoad: viewDidLoadPublisher.eraseToAnyPublisher())
+        self.input = SplashViewModel.Input(viewDidLoad: viewDidLoadPublisher.eraseToAnyPublisher())
         self.output = viewModel.transform(from: input)
         super.init(nibName: nil, bundle: nil)
     }
@@ -65,7 +65,7 @@ final class SplashViewController: UIViewController {
             .store(in: &cancellables)
     }
     
-    private func switchNextViewController(_ nextScreenType: SplahViewModel.NextScreenType) {
+    private func switchNextViewController(_ nextScreenType: SplashViewModel.NextScreenType) {
         let nextViewController = switch nextScreenType {
         case .login:
             LoginViewController(viewModel: LoginViewModel())

--- a/Molio/Source/Presentation/Splash/ViewModel/SplahViewModel.swift
+++ b/Molio/Source/Presentation/Splash/ViewModel/SplahViewModel.swift
@@ -10,27 +10,69 @@ final class SplahViewModel: InputOutputViewModel {
         let navigateToNextScreen: AnyPublisher<NextScreenType, Never>
     }
     
+    private let fetchPlaylistUseCase: FetchPlaylistUseCase
+    private let managePlaylistUseCase: ManageMyPlaylistUseCase
     private let manageAuthenticationUseCase: ManageAuthenticationUseCase
     private let navigateToNextScreenPublisher = PassthroughSubject<NextScreenType, Never>()
     private var cancellables = Set<AnyCancellable>()
     
-    init(manageAuthenticationUseCase: ManageAuthenticationUseCase = DIContainer.shared.resolve()) {
+    init(
+        fetchPlaylistUseCase: FetchPlaylistUseCase = DIContainer.shared.resolve(),
+        managePlaylistUseCase: ManageMyPlaylistUseCase = DIContainer.shared.resolve(),
+        manageAuthenticationUseCase: ManageAuthenticationUseCase = DIContainer.shared.resolve()
+    ) {
+        self.fetchPlaylistUseCase = fetchPlaylistUseCase
+        self.managePlaylistUseCase = managePlaylistUseCase
         self.manageAuthenticationUseCase = manageAuthenticationUseCase
     }
     
     func transform(from input: Input) -> Output {
         input.viewDidLoad
-            .delay(for: .seconds(1.5), scheduler: RunLoop.main)
-            .sink { [weak self] _ in
-                guard let self else { return }
-                let nextScreen = manageAuthenticationUseCase.isAuthModeSelected() 
-                ? NextScreenType.main
-                : NextScreenType.login
-                navigateToNextScreenPublisher.send(nextScreen)
+            .flatMap { [weak self] _ -> AnyPublisher<NextScreenType, Never> in
+                guard let self else { return Just(NextScreenType.login).eraseToAnyPublisher() }
+                
+                /// 스플래쉬 화면 최소 시간
+                let delayPublisher = Just(())
+                    .delay(for: .seconds(1.5), scheduler: DispatchQueue.main)
+                
+                /// 로그인, 게스트 모드를 선택했는지 여부 확인
+                let nextScreenPublisher = Just(
+                    self.manageAuthenticationUseCase.isAuthModeSelected()
+                    ? NextScreenType.main
+                    : NextScreenType.login
+                )
+                
+                /// 현재 최소 플
+                let playlistCheckPublisher = Future<Void, Never> { promise in
+                    Task {
+                        let sholudCreateDefaultPlaylist = try await self.shouldCreateDefaultPlaylist()
+                        if sholudCreateDefaultPlaylist {
+                            try await self.makeDefaultPlayList()
+                        }
+                        promise(.success(()))
+                    }
+                }
+                
+                return Publishers.CombineLatest3(delayPublisher, nextScreenPublisher, playlistCheckPublisher)
+                    .map { _, nextScreen, _ in nextScreen }
+                    .eraseToAnyPublisher()
+            }
+            .sink { [weak self] nextScreen in
+                self?.navigateToNextScreenPublisher.send(nextScreen)
             }
             .store(in: &cancellables)
         
         return Output(navigateToNextScreen: navigateToNextScreenPublisher.eraseToAnyPublisher())
+    }
+    
+    /// 기본 플레이리스트 생성해야하는지 여부를 나타내는 메서드
+    private func shouldCreateDefaultPlaylist() async throws -> Bool {
+        try await fetchPlaylistUseCase.fetchMyAllPlaylists().isEmpty
+    }
+    
+    /// 기본 플레이리스트를 생성하는 메서드
+    private func makeDefaultPlayList() async throws {
+        try await managePlaylistUseCase.createPlaylist(playlistName: "기본 플레이리스트")
     }
     
     enum NextScreenType {

--- a/Molio/Source/Presentation/Splash/ViewModel/SplashViewModel.swift
+++ b/Molio/Source/Presentation/Splash/ViewModel/SplashViewModel.swift
@@ -1,7 +1,7 @@
 import Combine
 import Foundation
 
-final class SplahViewModel: InputOutputViewModel {
+final class SplashViewModel: InputOutputViewModel {
     struct Input {
         let viewDidLoad: AnyPublisher<Void, Never>
     }

--- a/Molio/Source/Presentation/Splash/ViewModel/SplashViewModel.swift
+++ b/Molio/Source/Presentation/Splash/ViewModel/SplashViewModel.swift
@@ -42,7 +42,7 @@ final class SplashViewModel: InputOutputViewModel {
                     : NextScreenType.login
                 )
                 
-                /// 현재 최소 플
+                /// 현재 갖고있는 플레이리스트가 없다면 기본 플레이리스트 생성
                 let playlistCheckPublisher = Future<Void, Never> { promise in
                     Task {
                         let sholudCreateDefaultPlaylist = try await self.shouldCreateDefaultPlaylist()


### PR DESCRIPTION
## 1. 이슈 내용
스플래쉬 화면에서 사용자의 플레이리스트가 하나도 없을 시 기본 플레이리스트를 생성한 뒤에 화면 이동처리를 합니다.

## 2. TODO
- [x] 스플래쉬 화면에서 사용자의 플레이리스트 개수를 확인
- [x] 플레이리스트가 하나도 없는 경우 기본 플레이리스트 생성이후 화면 넘긴다.

## 3. 스크린샷

|   11PRO   | 
|  :-------------: |
| <img width=200 src="https://github.com/user-attachments/assets/6881389b-fd25-40fc-af98-309f3fecfab1"> | 


## 4. Issue 번호
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #297 