### PR TITLE
setting: Localization에 한국어 추가

### DIFF
--- a/Molio/Resource/Info.plist
+++ b/Molio/Resource/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>ko</string>
+	</array>
 	<key>SPOTIFY_CLIENT_ID</key>
 	<string>$(SPOTIFY_CLIENT_ID)</string>
 	<key>SPOTIFY_CLIENT_SECRET</key>


### PR DESCRIPTION
## 1. 배경
#316 

## 2. 작업 내용
- [x] 프로젝트 Localizations 목록에 한국어 추가

이제 필터(장르)이름과 가수/노래제목 모두 한국 기준으로 나옵니다!
나중에 다양한 로컬라이제이션도 적용해보면 좋을 것 같군요ㅎㅎ

[작업 문서 🔗](https://south-petunia-a75.notion.site/MusicKit-c320f993df5f4340a027c62dee0e8fa1?pvs=4)

## 3. 스크린샷

|   SE   |   16PRO   | 
| :-------------: |  :-------------: |
| <img width=200 src="https://github.com/user-attachments/assets/aab7576b-eefb-4f03-845d-57cf1466c0ed"> | <img width=200 src="https://github.com/user-attachments/assets/0946b917-707f-4520-af5f-980da2906fff"> | 


## 4. Issue 번호
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #316 

## 5. 참고자료
<!-- !없을 시 지워도됩니다. -->
<!-- 주석, 디버깅, 로그, 프린트문 다 제거해서 올려주세요. -->