### PR TITLE
bugfix: 메인 Swipe 화면 버튼 클릭시 색상 오류 수정

### DIFF
--- a/Molio/Source/Presentation/Common/Component/CircleMenuButton.swift
+++ b/Molio/Source/Presentation/Common/Component/CircleMenuButton.swift
@@ -1,24 +1,21 @@
 import UIKit
 
 final class CircleMenuButton: UIButton {
-    
-    private var defaultBackgroundColor: UIColor
-    private var highlightBackgroundColor: UIColor
-    private let blurEffectView: UIVisualEffectView = {
+    private let defaultBackgroundColor: UIColor
+    private let highlightBackgroundColor: UIColor
+    private var blurEffectView: UIVisualEffectView = {
         let blurEffect = UIBlurEffect(style: .systemMaterialDark)
         let effectView = UIVisualEffectView(effect: blurEffect)
-        effectView.translatesAutoresizingMaskIntoConstraints = false
-        effectView.layer.cornerRadius = 0 // 초기값, 버튼 크기에 따라 조정
         effectView.clipsToBounds = true
-        effectView.isUserInteractionEnabled = false // 터치 이벤트를 블러 뷰가 소모하지 않도록 설정
+        effectView.isUserInteractionEnabled = false
         effectView.alpha = 0.5
-
+        effectView.translatesAutoresizingMaskIntoConstraints = false
         return effectView
     }()
     
     override var isHighlighted: Bool {
         didSet {
-            self.backgroundColor = isHighlighted ? highlightBackgroundColor : defaultBackgroundColor
+            self.blurEffectView.backgroundColor = isHighlighted ? highlightBackgroundColor : defaultBackgroundColor
         }
     }
     
@@ -29,23 +26,29 @@ final class CircleMenuButton: UIButton {
         return imageView
     }()
     
-    init(backgroundColor: UIColor,
-         highlightColor: UIColor? = nil,
-         buttonSize: CGFloat,
-         tintColor: UIColor?,
-         buttonImage: UIImage?,
-         buttonImageSize: CGSize
+    init(
+        backgroundColor: UIColor,
+        highlightColor: UIColor? = nil,
+        buttonSize: CGFloat,
+        tintColor: UIColor?,
+        buttonImage: UIImage?,
+        buttonImageSize: CGSize
     ) {
         self.defaultBackgroundColor = backgroundColor
         self.highlightBackgroundColor = highlightColor ?? backgroundColor.withAlphaComponent(0.8)
         super.init(frame: .zero)
         self.translatesAutoresizingMaskIntoConstraints = false
-        setupView(backgroundColor: backgroundColor,
-                  buttonSize: buttonSize,
-                  tintColor: tintColor,
-                  buttonImage: buttonImage)
+        setupView(
+            backgroundColor: backgroundColor,
+            buttonSize: buttonSize,
+            tintColor: tintColor,
+            buttonImage: buttonImage
+        )
         setupHierarchy()
-        setupConstraint(buttonSize: buttonSize, buttonImageSize: buttonImageSize)
+        setupConstraint(
+            buttonSize: buttonSize,
+            buttonImageSize: buttonImageSize
+        )
     }
     
     required init?(coder: NSCoder) {
@@ -54,18 +57,19 @@ final class CircleMenuButton: UIButton {
         super.init(coder: coder)
     }
     
-    private func setupView(backgroundColor: UIColor,
-                           buttonSize: CGFloat,
-                           tintColor: UIColor?,
-                           buttonImage: UIImage?
+    private func setupView(
+        backgroundColor: UIColor,
+        buttonSize: CGFloat,
+        tintColor: UIColor?,
+        buttonImage: UIImage?
     ) {
-        // Apply blur effect for glassmorphism
-        blurEffectView.layer.cornerRadius = buttonSize / 2
-        self.insertSubview(blurEffectView, at: 0)
+        self.backgroundColor = .clear
+        self.clipsToBounds = true
+        self.layer.cornerRadius = buttonSize / 2
         
-        self.backgroundColor = .clear // Transparent to show blur effect
-        layer.cornerRadius = buttonSize / 2
-        clipsToBounds = true
+        blurEffectView.layer.cornerRadius = buttonSize / 2
+        blurEffectView.backgroundColor = backgroundColor
+        
         buttonImageView.tintColor = tintColor
         buttonImageView.image = buttonImage
     }


### PR DESCRIPTION
## 1. 이슈 내용
Swipe 뮤직 화면에서 버튼을 클릭하게 되면 기존 색상이 변경되는 오류를 해결하려고 합니다.

## 2. TODO
- [x] 메인화면 버튼 클릭 시 색상 변경 오류 해결

하이라이트 되는 버튼의 색상을 잘 봐주시기 바랍니다.
이전의 색상보다 많이 연해졌습니다.
블러처리를 위해서는 버튼의 배경색을 clear로 처리해야하고, 블러처리의 배경색으로 표시해야하기 때문입니다.

## 3. 스크린샷

|   15Pro   |
|  :-------------: | 
| <img width=200 src="https://github.com/user-attachments/assets/5524ec2d-9ae8-43d8-a37d-ff69c298ae4d"> | 

## 4. Issue 번호
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #319