### PR TITLE
bugfix: 음악 카드 제목 텍스트 잘리지 않도록 수정

### DIFF
--- a/Molio/Source/Presentation/SwipeMusic/View/MusicCardView.swift
+++ b/Molio/Source/Presentation/SwipeMusic/View/MusicCardView.swift
@@ -25,6 +25,7 @@ final class MusicCardView: UIView {
         let label = UILabel()
         label.textColor = .white
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 0
         return label
     }()
     


### PR DESCRIPTION
## 1. 배경
ㅈㄱㄴ

## 2. 작업 내용
- [x] ㅈㄱㄴ

## 3. 스크린샷

|   SE  |   SE   |   SE   | 
| :-------------: |  :-------------: |  :-------------: |
| <img width=200 src="https://github.com/user-attachments/assets/c968a893-2e09-4ef2-98ab-392455264856"> | <img width=200 src="https://github.com/user-attachments/assets/960860e3-13e5-4b01-bd6e-c34aeba792e6"> | <img width=200 src="https://github.com/user-attachments/assets/ec67e7cd-33fe-49d4-8bf2-09e92967800a"> | 

|   16PRO  |   16PRO   |   16PRO   | 
| :-------------: |  :-------------: |  :-------------: |
| <img width=200 src="https://github.com/user-attachments/assets/6f7807b7-e415-41ce-ae6a-481570d4d7b8"> | <img width=200 src="https://github.com/user-attachments/assets/ee85b34c-3a84-48b1-b931-e410f1416c59"> | <img width=200 src="https://github.com/user-attachments/assets/3f9fec43-9ef0-4ae2-aa29-dd362ae78593"> | 




## 4. Issue 번호
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #321 
