### PR TITLE
refactor: 카드 스와이프 임계값 수정

### DIFF
--- a/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
+++ b/Molio/Source/Presentation/SwipeMusic/View/SwipeMusicViewController.swift
@@ -220,6 +220,11 @@ final class SwipeMusicViewController: UIViewController {
                 if isMusicCardAnimating {
                     self.pendingMusic.currentMusic = music
                 } else {
+                    let currentCardBackgroundColor = music.artworkBackgroundColor
+                        .flatMap { UIColor(rgbaColor: $0) } ?? self.basicBackgroundColor
+                    UIView.animate(withDuration: 0.3, animations: {
+                        self.view.backgroundColor = currentCardBackgroundColor
+                    })
                     self.updateCurrentCard(with: music)
                 }
                 currentCardBackgroundColor = music.artworkBackgroundColor

--- a/Molio/Source/Presentation/SwipeMusic/ViewModel/SwipeMusicViewModel.swift
+++ b/Molio/Source/Presentation/SwipeMusic/ViewModel/SwipeMusicViewModel.swift
@@ -1,6 +1,7 @@
-import Foundation
 import Combine
+import Foundation
 import MusicKit
+import UIKit
 
 final class SwipeMusicViewModel: InputOutputViewModel {
     struct Input {
@@ -13,7 +14,7 @@ final class SwipeMusicViewModel: InputOutputViewModel {
     
     struct Output {
         let selectedPlaylist: AnyPublisher<MolioPlaylist, Never>
-        let isLoading: AnyPublisher<Bool, Never> // TODO: 로딩 UI 구현 및 연결
+        let isLoading: AnyPublisher<Bool, Never>
         let buttonHighlight: AnyPublisher<ButtonHighlight, Never>
         let musicCardSwipeAnimation: AnyPublisher<SwipeDirection, Never>
         let currentMusicTrack: AnyPublisher<SwipeMusicTrackModel, Never>
@@ -33,7 +34,8 @@ final class SwipeMusicViewModel: InputOutputViewModel {
     }
     
     var swipeThreshold: CGFloat {
-        return 170.0
+        let cardViewMargin: CGFloat = 44
+        return (UIScreen.main.bounds.width - cardViewMargin) / 2
     }
     
     private let musicDeck: any RandomMusicDeck


### PR DESCRIPTION
## 1. 이슈 내용
카드 스와이프의 임계값이 기기마다 다르지 않고 고정되어있습니다.
애플 디자인가이드라인에는 임계값에 대한 이야기가 없어서
안드로이드의 경우 50%를 기준으로 하기 때문에, 카드 크기의 50%를 기준으로 작업하도록 하겠습니다.

## 2. TODO
- [x] 카드 임계값 수정

## 3. 참고자료
[Swipe to reveal](https://developer.android.com/design/ui/wear/guides/components/swipe-to-reveal)

## 4. Issue 번호
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #354 